### PR TITLE
Bump odlparent to 4.0.9

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.9</version>
         <relativePath />
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.9</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.9</version>
         <relativePath />
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.9</version>
         <relativePath />
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.9</version>
         <relativePath />
     </parent>
 
@@ -106,6 +106,9 @@
                             <additionalOptions>
                                 <additionalOption>-html5</additionalOption>
                             </additionalOptions>
+
+                            <!-- https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                            <source>8</source>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Not that we need it, but it has some plugin updates.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>