### PR TITLE
Add module-info.java

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -33,13 +33,6 @@
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -48,7 +41,6 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>tech.pantheon.triemap</Bundle-SymbolicName>
-                        <Multi-Release>true</Multi-Release>
                     </instructions>
                 </configuration>
             </plugin>
@@ -66,25 +58,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>codes.rafael.modulemaker</groupId>
-                <artifactId>modulemaker-maven-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>inject-module</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <name>tech.pantheon.triemap</name>
-                    <exports>tech.pantheon.triemap</exports>
-                    <multirelease>true</multirelease>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/triemap/src/main/java/module-info.java
+++ b/triemap/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+/*
+ * (C) Copyright 2019 PANTHEON.tech, s.r.o. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module tech.pantheon.triemap {
+    exports tech.pantheon.triemap;
+
+    requires static com.github.spotbugs.annotations;
+    requires static org.eclipse.jdt.annotation;
+}

--- a/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
@@ -19,14 +19,19 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class FailedNodeTest {
-    @Mock
-    private MainNode<Object, Object> main;
+    private final MainNode<Object, Object> main = new MainNode<>() {
+        @Override
+        int trySize() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        int size(ImmutableTrieMap<?, ?> ct) {
+            throw new IllegalStateException();
+        }
+    };
 
     private FailedNode<Object, Object> failed;
 


### PR DESCRIPTION
Rather than constructing this information through a plugin,
add module-info.java now that we require Java 11 to build.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>