### PR TITLE
Remove (mis-)use of Optional

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -22,7 +22,7 @@ import static tech.pantheon.triemap.PresencePredicate.PRESENT;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.util.Optional;
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * A mutable TrieMap.
@@ -66,20 +66,20 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @Override
     public V put(final K key, final V value) {
         final K k = requireNonNull(key);
-        return toNullable(insertifhc(k, computeHash(k), requireNonNull(value), null));
+        return insertifhc(k, computeHash(k), requireNonNull(value), null).orNull();
     }
 
     @Override
     public V putIfAbsent(final K key, final V value) {
         final K k = requireNonNull(key);
-        return toNullable(insertifhc(k, computeHash(k), requireNonNull(value), ABSENT));
+        return insertifhc(k, computeHash(k), requireNonNull(value), ABSENT).orNull();
     }
 
     @Override
     public V remove(final Object key) {
         @SuppressWarnings("unchecked")
         final K k = (K) requireNonNull(key);
-        return toNullable(removehc(k, null, computeHash(k)));
+        return removehc(k, null, computeHash(k)).orNull();
     }
 
     @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE",
@@ -100,7 +100,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @Override
     public V replace(final K key, final V value) {
         final K k = requireNonNull(key);
-        return toNullable(insertifhc(k, computeHash(k), requireNonNull(value), PRESENT));
+        return insertifhc(k, computeHash(k), requireNonNull(value), PRESENT).orNull();
     }
 
     @Override
@@ -179,8 +179,8 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         }
     }
 
-    private Optional<V> insertifhc(final K key, final int hc, final V value, final Object cond) {
-        Optional<V> res;
+    private @NonNull Result<V> insertifhc(final K key, final int hc, final V value, final Object cond) {
+        Result<V> res;
         do {
             // Keep looping as long as we do not get a reply
             res = readRoot().recInsertIf(key, value, hc, cond, 0, null, this);
@@ -189,8 +189,8 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         return res;
     }
 
-    private Optional<V> removehc(final K key, final Object cond, final int hc) {
-        Optional<V> res;
+    private @NonNull Result<V> removehc(final K key, final Object cond, final int hc) {
+        Result<V> res;
         do {
             // Keep looping as long as we do not get a reply
             res = readRoot().recRemove(key, cond, hc, 0, null, this);

--- a/triemap/src/main/java/tech/pantheon/triemap/Result.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Result.java
@@ -1,0 +1,52 @@
+/*
+ * (C) Copyright 2020 PANTHEON.tech, s.r.o. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tech.pantheon.triemap;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+/**
+ * Insertion result, similar to {@link java.util.Optional}, except heavily customized for our use.
+ */
+final class Result<T> {
+    private static final @NonNull Result<?> EMPTY = new Result<>(null);
+
+    private final T value;
+
+    private Result(final T value) {
+        this.value = value;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> @NonNull Result<T> empty() {
+        return (Result<T>) EMPTY;
+    }
+
+    static <T> @NonNull Result<T> of(final LNodeEntry<?, T> entry) {
+        return new Result<>(entry.getValue());
+    }
+
+    static <T> @NonNull Result<T> of(final SNode<?, T> snode) {
+        return new Result<>(snode.value);
+    }
+
+    boolean isPresent() {
+        return value != null;
+    }
+
+    T orNull() {
+        return value;
+    }
+}

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -21,7 +21,6 @@ import static tech.pantheon.triemap.LookupResult.RESTART;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
@@ -171,11 +170,6 @@ public abstract class TrieMap<K, V> extends AbstractMap<K, V> implements Concurr
      */
     final ImmutableIterator<K, V> immutableIterator() {
         return new ImmutableIterator<>(immutableSnapshot());
-    }
-
-    @SuppressWarnings("null")
-    static <V> V toNullable(final Optional<V> opt) {
-        return opt.orElse(null);
     }
 
     static final int computeHash(final Object key) {


### PR DESCRIPTION
SpotBugs does not like our creative of Optional, just because it
recognizes the intent behind it. Introduce an explicit Result class,
which is designed pretty much the same.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>