### PR TITLE
Remove unneeded specifiers

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
@@ -78,7 +78,7 @@ abstract class AbstractKeySet<K> extends AbstractSet<K> {
     abstract int spliteratorCharacteristics();
 
     final Iterator<K> immutableIterator() {
-        return new Iterator<K>() {
+        return new Iterator<>() {
             private final ImmutableIterator<K, ?> itr = map().immutableIterator();
 
             @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
@@ -32,7 +32,7 @@ final class MutableKeySet<K> extends AbstractKeySet<K> {
 
     @Override
     public Iterator<K> iterator() {
-        return new Iterator<K>() {
+        return new Iterator<>() {
             private final AbstractIterator<K, ?> itr = map().iterator();
 
             @Override


### PR DESCRIPTION
With Java 11 type inference is good enough to infer type arguments
of anonymous subclasses. Take advantage of that.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>