### PR TITLE
Mark fields as transient

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -33,8 +33,8 @@ import java.util.function.Function;
 public final class ImmutableTrieMap<K, V> extends TrieMap<K, V> {
     private static final long serialVersionUID = 1L;
 
-    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "Handled by SerializationProxy")
-    private final INode<K, V> root;
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")
+    private final transient INode<K, V> root;
 
     ImmutableTrieMap(final INode<K, V> root) {
         this.root = requireNonNull(root);

--- a/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
@@ -36,8 +36,8 @@ import java.util.Map.Entry;
 final class SerializationProxy implements Externalizable {
     private static final long serialVersionUID = 1L;
 
-    private TrieMap<Object, Object> map;
-    private boolean readOnly;
+    private transient TrieMap<Object, Object> map;
+    private transient boolean readOnly;
 
     @SuppressWarnings("checkstyle:redundantModifier")
     public SerializationProxy() {

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -38,8 +38,8 @@ import java.util.concurrent.ConcurrentMap;
 public abstract class TrieMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,V>, Serializable {
     private static final long serialVersionUID = 1L;
 
-    private AbstractEntrySet<K, V> entrySet;
-    private AbstractKeySet<K> keySet;
+    private transient AbstractEntrySet<K, V> entrySet;
+    private transient AbstractKeySet<K> keySet;
 
     TrieMap() {
         // Hidden on purpose

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
@@ -17,6 +17,7 @@ package tech.pantheon.triemap;
 
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -41,9 +42,11 @@ import java.util.stream.Stream;
 public abstract class TrieSet<E> implements Set<E>, Serializable {
     private static final long serialVersionUID = 0L;
 
-    private final TrieMap<E, Boolean> map;
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")
+    private final transient TrieMap<E, Boolean> map;
     // Cached map keyset view, so we do not re-checking it all over
-    private final AbstractKeySet<E> set;
+    @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")
+    private final transient AbstractKeySet<E> set;
 
     TrieSet(final TrieMap<E, Boolean> map) {
         this.map = requireNonNull(map);
@@ -211,7 +214,7 @@ public abstract class TrieSet<E> implements Set<E>, Serializable {
     private static final class SerializedForm implements Externalizable {
         private static final long serialVersionUID = 0L;
 
-        private TrieSet<?> set;
+        private transient TrieSet<?> set;
 
         @SuppressWarnings("checkstyle:redundantModifier")
         public SerializedForm() {


### PR DESCRIPTION
Sonar does not like the fields not being marked as transient,
which is fair. SpotBugs does not like then does not like them being
dealt with via serialization proxies, hence suppress that.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>