### PR TITLE
Add LGTM configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: 11


### PR DESCRIPTION
We needs Java 11, add the appropriate configuration.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>