### PR TITLE
Bump odlparent to 10.0.6

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,3 +2,5 @@ extraction:
   java:
     index:
       java_version: 11
+      maven:
+        version: 3.9.1

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>9.0.5</version>
+        <version>10.0.6</version>
         <relativePath/>
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>9.0.5</version>
+        <version>10.0.6</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>9.0.5</version>
+        <version>10.0.6</version>
         <relativePath/>
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>9.0.5</version>
+        <version>10.0.6</version>
         <relativePath/>
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>9.0.5</version>
+        <version>10.0.6</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Pick up last version for Java 11, upgrading testing infrastructure. Fixes #94.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>