### PR TITLE
Modernize for Java 11

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -48,13 +48,13 @@ abstract class AbstractEntrySet<K, V> extends AbstractSet<Entry<K, V>> {
             return false;
         }
 
-        final Entry<?, ?> e = (Entry<?, ?>) o;
-        final Object key = e.getKey();
+        final var e = (Entry<?, ?>) o;
+        final var key = e.getKey();
         if (key == null) {
             return false;
         }
 
-        final V v = map.get(key);
+        final var v = map.get(key);
         return v != null && v.equals(e.getValue());
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -85,10 +85,10 @@ abstract class AbstractIterator<K, V> implements Iterator<Entry<K, V>> {
      * @param in INode to be read.
      */
     private void readin(final INode<K, V> in) {
-        final MainNode<K, V> m = in.gcasRead(map);
+        final var m = in.gcasRead(map);
         if (m instanceof CNode) {
             // Enter the next level
-            final CNode<K, V> cn = (CNode<K, V>) m;
+            final var cn = (CNode<K, V>) m;
             depth++;
             nodeStack[depth] = cn.array;
             positionStack[depth] = -1;
@@ -108,7 +108,7 @@ abstract class AbstractIterator<K, V> implements Iterator<Entry<K, V>> {
             int npos = positionStack[depth] + 1;
             if (npos < nodeStack[depth].length) {
                 positionStack [depth] = npos;
-                BasicNode elem = nodeStack[depth][npos];
+                var elem = nodeStack[depth][npos];
                 if (elem instanceof SNode) {
                     current = (SNode<K, V>) elem;
                 } else if (elem instanceof INode) {

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -114,27 +114,27 @@ final class CNode<K, V> extends MainNode<K, V> {
     }
 
     CNode<K, V> updatedAt(final int pos, final BasicNode nn, final Gen newGen) {
-        int len = array.length;
-        BasicNode[] narr = new BasicNode[len];
+        final int len = array.length;
+        final var narr = new BasicNode[len];
         System.arraycopy(array, 0, narr, 0, len);
         narr[pos] = nn;
         return new CNode<>(newGen, bitmap, narr);
     }
 
     CNode<K, V> removedAt(final int pos, final int flag, final Gen newGen) {
-        BasicNode[] arr = array;
-        int len = arr.length;
-        BasicNode[] narr = new BasicNode[len - 1];
+        final var arr = array;
+        final int len = arr.length;
+        final var narr = new BasicNode[len - 1];
         System.arraycopy(arr, 0, narr, 0, pos);
         System.arraycopy(arr, pos + 1, narr, pos, len - pos - 1);
         return new CNode<>(newGen, bitmap ^ flag, narr);
     }
 
     CNode<K, V> insertedAt(final int pos, final int flag, final BasicNode nn, final Gen newGen) {
-        int len = array.length;
-        BasicNode[] narr = new BasicNode[len + 1];
+        final int len = array.length;
+        final var narr = new BasicNode[len + 1];
         System.arraycopy(array, 0, narr, 0, pos);
-        narr [pos] = nn;
+        narr[pos] = nn;
         System.arraycopy(array, pos, narr, pos + 1, len - pos);
         return new CNode<>(newGen, bitmap | flag, narr);
     }
@@ -145,11 +145,11 @@ final class CNode<K, V> extends MainNode<K, V> {
      */
     CNode<K, V> renewed(final Gen ngen, final TrieMap<K, V> ct) {
         int idx = 0;
-        final BasicNode[] arr = array;
+        final var arr = array;
         final int len = arr.length;
-        final BasicNode[] narr = new BasicNode[len];
+        final var narr = new BasicNode[len];
         while (idx < len) {
-            final BasicNode elem = arr[idx];
+            final var elem = arr[idx];
             if (elem instanceof INode) {
                 narr[idx] = ((INode<?, ?>) elem).copyToGen(ngen, ct);
             } else if (elem != null) {
@@ -168,7 +168,6 @@ final class CNode<K, V> extends MainNode<K, V> {
             }
             return this;
         }
-
         return this;
     }
 
@@ -177,12 +176,13 @@ final class CNode<K, V> extends MainNode<K, V> {
     //   null-inodes removed (those existing when the op began)
     // - if there are only null-i-nodes below, returns null
     MainNode<K, V> toCompressed(final TrieMap<?, ?> ct, final int lev, final Gen newGen) {
-        int bmp = bitmap;
+        final int bmp = bitmap;
+        final var arr = array;
+        final var tmparray = new BasicNode[arr.length];
         int idx = 0;
-        BasicNode[] arr = array;
-        BasicNode[] tmparray = new BasicNode[arr.length];
+
         while (idx < arr.length) { // construct new bitmap
-            BasicNode sub = arr[idx];
+            var sub = arr[idx];
             if (sub instanceof INode) {
                 final INode<?, ?> in = (INode<?, ?>) sub;
                 final MainNode<?, ?> inodemain = VerifyException.throwIfNull(in.gcasRead(ct));
@@ -202,9 +202,6 @@ final class CNode<K, V> extends MainNode<K, V> {
 
     @Override
     public String toString() {
-        // val elems = collectLocalElems
-        // "CNode(sz: %d; %s)".format(elems.size,
-        // elems.sorted.mkString(", "))
         return "CNode";
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -22,7 +22,7 @@ package tech.pantheon.triemap;
  */
 final class Constants {
     private Constants() {
-
+        // Hidden on purpose
     }
 
     /**

--- a/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
@@ -24,7 +24,7 @@ import java.util.Map.Entry;
  */
 final class EntryUtil {
     private EntryUtil() {
-
+        // Hidden on purpose
     }
 
     /**

--- a/triemap/src/main/java/tech/pantheon/triemap/Gen.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Gen.java
@@ -16,5 +16,5 @@
 package tech.pantheon.triemap;
 
 final class Gen {
-
+    // Just an identity object
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -45,8 +45,8 @@ final class INode<K, V> extends BasicNode {
     }
 
     MainNode<K, V> gcasRead(final TrieMap<?, ?> ct) {
-        MainNode<K, V> main = /* READ */ mainnode;
-        MainNode<K, V> prevval = /* READ */ main.readPrev();
+        final var main = /* READ */ mainnode;
+        final var prevval = /* READ */ main.readPrev();
         if (prevval == null) {
             return main;
         }
@@ -55,7 +55,7 @@ final class INode<K, V> extends BasicNode {
     }
 
     private MainNode<K, V> gcasComplete(final MainNode<K, V> oldmain, final TrieMap<?, ?> ct) {
-        MainNode<K, V> main = oldmain;
+        var main = oldmain;
         while (main != null) {
             // complete the GCAS
             final MainNode<K, V> prev = /* READ */ main.readPrev();
@@ -148,10 +148,10 @@ final class INode<K, V> extends BasicNode {
 
                 if ((bmp & flag) != 0) {
                     // 1a) insert below
-                    final BasicNode cnAtPos = cn.array[pos];
+                    final var cnAtPos = cn.array[pos];
                     if (cnAtPos instanceof INode) {
                         @SuppressWarnings("unchecked")
-                        final INode<K, V> in = (INode<K, V>) cnAtPos;
+                        final var in = (INode<K, V>) cnAtPos;
                         if (startgen == in.gen) {
                             return in.recInsert(key, val, hc, lev + LEVEL_BITS, this, startgen, ct);
                         }
@@ -163,29 +163,29 @@ final class INode<K, V> extends BasicNode {
                         return false;
                     } else if (cnAtPos instanceof SNode) {
                         @SuppressWarnings("unchecked")
-                        final SNode<K, V> sn = (SNode<K, V>) cnAtPos;
+                        final var sn = (SNode<K, V>) cnAtPos;
                         if (sn.hc == hc && key.equals(sn.key)) {
                             return gcas(cn, cn.updatedAt(pos, new SNode<>(key, val, hc), gen), ct);
                         }
 
-                        final CNode<K, V> rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
-                        final MainNode<K, V> nn = rn.updatedAt(pos, inode(
-                            CNode.dual(sn, key, val, hc, lev + LEVEL_BITS, gen)), gen);
+                        final var rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
+                        final var nn = rn.updatedAt(pos, inode(CNode.dual(sn, key, val, hc, lev + LEVEL_BITS, gen)),
+                            gen);
                         return gcas(cn, nn, ct);
                     } else {
                         throw CNode.invalidElement(cnAtPos);
                     }
                 }
 
-                final CNode<K, V> rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
-                final MainNode<K, V> ncnode = rn.insertedAt(pos, flag, new SNode<>(key, val, hc), gen);
+                final var rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
+                final var ncnode = rn.insertedAt(pos, flag, new SNode<>(key, val, hc), gen);
                 return gcas(cn, ncnode, ct);
             } else if (m instanceof TNode) {
                 clean(parent, ct, lev - LEVEL_BITS);
                 return false;
             } else if (m instanceof LNode) {
-                final LNode<K, V> ln = (LNode<K, V>) m;
-                final LNodeEntry<K, V> entry = ln.get(key);
+                final var ln = (LNode<K, V>) m;
+                final var entry = ln.get(key);
                 return entry != null ? replaceln(ln, entry, val, ct) : insertln(ln, key, val, ct);
             } else {
                 throw invalidElement(m);
@@ -199,8 +199,8 @@ final class INode<K, V> extends BasicNode {
 
     private @Nullable Result<V> insertDual(final TrieMap<K, V> ct, final CNode<K, V> cn, final int pos,
             final SNode<K, V> sn, final K key, final V val, final int hc, final int lev) {
-        final CNode<K, V> rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
-        final MainNode<K, V> nn = rn.updatedAt(pos, inode(CNode.dual(sn, key, val, hc, lev + LEVEL_BITS, gen)), gen);
+        final var rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
+        final var nn = rn.updatedAt(pos, inode(CNode.dual(sn, key, val, hc, lev + LEVEL_BITS, gen)), gen);
         return gcas(cn, nn, ct) ? Result.empty() : null;
     }
 
@@ -222,7 +222,7 @@ final class INode<K, V> extends BasicNode {
     private @Nullable Result<V> recInsertIf(final K key, final V val, final int hc, final Object cond, final int lev,
             final INode<K, V> parent, final Gen startgen, final TrieMap<K, V> ct) {
         while (true) {
-            final MainNode<K, V> m = gcasRead(ct);
+            final var m = gcasRead(ct);
 
             if (m instanceof CNode) {
                 // 1) a multiway node
@@ -238,7 +238,7 @@ final class INode<K, V> extends BasicNode {
                     final BasicNode cnAtPos = cn.array[pos];
                     if (cnAtPos instanceof INode) {
                         @SuppressWarnings("unchecked")
-                        final INode<K, V> in = (INode<K, V>) cnAtPos;
+                        final var in = (INode<K, V>) cnAtPos;
                         if (startgen == in.gen) {
                             return in.recInsertIf(key, val, hc, cond, lev + LEVEL_BITS, this, startgen, ct);
                         }
@@ -251,7 +251,7 @@ final class INode<K, V> extends BasicNode {
                         return null;
                     } else if (cnAtPos instanceof SNode) {
                         @SuppressWarnings("unchecked")
-                        final SNode<K, V> sn = (SNode<K, V>) cnAtPos;
+                        final var sn = (SNode<K, V>) cnAtPos;
                         if (cond == null) {
                             if (sn.hc == hc && key.equals(sn.key)) {
                                 if (gcas(cn, cn.updatedAt(pos, new SNode<>(key, val, hc), gen), ct)) {
@@ -292,13 +292,9 @@ final class INode<K, V> extends BasicNode {
                         throw CNode.invalidElement(cnAtPos);
                     }
                 } else if (cond == null || cond == ABSENT) {
-                    final CNode<K, V> rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
-                    final CNode<K, V> ncnode = rn.insertedAt(pos, flag, new SNode<>(key, val, hc), gen);
-                    if (gcas(cn, ncnode, ct)) {
-                        return Result.empty();
-                    }
-
-                    return null;
+                    final var rn = cn.gen == gen ? cn : cn.renewed(gen, ct);
+                    final var ncnode = rn.insertedAt(pos, flag, new SNode<>(key, val, hc), gen);
+                    return gcas(cn, ncnode, ct) ? Result.empty() : null;
                 } else {
                     return Result.empty();
                 }
@@ -307,33 +303,19 @@ final class INode<K, V> extends BasicNode {
                 return null;
             } else if (m instanceof LNode) {
                 // 3) an l-node
-                final LNode<K, V> ln = (LNode<K, V>) m;
-                final LNodeEntry<K, V> entry = ln.get(key);
+                final var ln = (LNode<K, V>) m;
+                final var entry = ln.get(key);
 
                 if (cond == null) {
-                    if (entry != null) {
-                        return replaceln(ln, entry, val, ct) ? Result.of(entry) : null;
-                    }
-
-                    return insertln(ln, key, val, ct) ? Result.empty() : null;
+                    return entry != null ? replaceln(ln, entry, val, ct) ? Result.of(entry) : null
+                        : insertln(ln, key, val, ct) ? Result.empty() : null;
                 } else if (cond == ABSENT) {
-                    if (entry != null) {
-                        return Result.of(entry);
-                    }
-
-                    return insertln(ln, key, val, ct) ? Result.empty() : null;
+                    return entry != null ? Result.of(entry) : insertln(ln, key, val, ct) ? Result.empty() : null;
                 } else if (cond == PRESENT) {
-                    if (entry == null) {
-                        return Result.empty();
-                    }
-
-                    return replaceln(ln, entry, val, ct) ? Result.of(entry) : null;
+                    return entry == null ? Result.empty() : replaceln(ln, entry, val, ct) ? Result.of(entry) : null;
                 } else {
-                    if (entry == null || !cond.equals(entry.getValue())) {
-                        return Result.empty();
-                    }
-
-                    return replaceln(ln, entry, val, ct) ? Result.of(entry) : null;
+                    return entry == null || !cond.equals(entry.getValue()) ? Result.empty()
+                        : replaceln(ln, entry, val, ct) ? Result.of(entry) : null;
                 }
             } else {
                 throw invalidElement(m);
@@ -362,11 +344,11 @@ final class INode<K, V> extends BasicNode {
     private Object recLookup(final K key, final int hc, final int lev, final INode<K, V> parent, final Gen startgen,
             final TrieMap<K, V> ct) {
         while (true) {
-            final MainNode<K, V> m = gcasRead(ct);
+            final var m = gcasRead(ct);
 
             if (m instanceof CNode) {
                 // 1) a multinode
-                final CNode<K, V> cn = (CNode<K, V>) m;
+                final var cn = (CNode<K, V>) m;
                 final int idx = hc >>> lev & 0x1f;
                 final int flag = 1 << idx;
                 final int bmp = cn.bitmap;
@@ -378,10 +360,10 @@ final class INode<K, V> extends BasicNode {
 
                 // 1b) bitmap contains a value - descend
                 final int pos = bmp == 0xffffffff ? idx : Integer.bitCount(bmp & flag - 1);
-                final BasicNode sub = cn.array[pos];
+                final var sub = cn.array[pos];
                 if (sub instanceof INode) {
                     @SuppressWarnings("unchecked")
-                    final INode<K, V> in = (INode<K, V>) sub;
+                    final var in = (INode<K, V>) sub;
                     if (ct.isReadOnly() || startgen == in.gen) {
                         return in.recLookup(key, hc, lev + LEVEL_BITS, this, startgen, ct);
                     }
@@ -395,12 +377,8 @@ final class INode<K, V> extends BasicNode {
                 } else if (sub instanceof SNode) {
                     // 2) singleton node
                     @SuppressWarnings("unchecked")
-                    final SNode<K, V> sn = (SNode<K, V>) sub;
-                    if (sn.hc == hc && key.equals(sn.key)) {
-                        return sn.value;
-                    }
-
-                    return null;
+                    final var sn = (SNode<K, V>) sub;
+                    return sn.hc == hc && key.equals(sn.key) ? sn.value : null;
                 } else {
                     throw CNode.invalidElement(sub);
                 }
@@ -409,7 +387,7 @@ final class INode<K, V> extends BasicNode {
                 return cleanReadOnly((TNode<K, V>) m, lev, parent, ct, key, hc);
             } else if (m instanceof LNode) {
                 // 5) an l-node
-                final LNodeEntry<K, V> entry = ((LNode<K, V>) m).get(key);
+                final var entry = ((LNode<K, V>) m).get(key);
                 return entry != null ? entry.getValue() : null;
             } else {
                 throw invalidElement(m);
@@ -420,11 +398,7 @@ final class INode<K, V> extends BasicNode {
     private Object cleanReadOnly(final TNode<K, V> tn, final int lev, final INode<K, V> parent,
             final TrieMap<K, V> ct, final K key, final int hc) {
         if (ct.isReadOnly()) {
-            if (tn.hc == hc && key.equals(tn.key)) {
-                return tn.value;
-            }
-
-            return null;
+            return tn.hc == hc && key.equals(tn.key) ? tn.value : null;
         }
 
         clean(parent, ct, lev - LEVEL_BITS);
@@ -448,10 +422,10 @@ final class INode<K, V> extends BasicNode {
 
     private @Nullable Result<V> recRemove(final K key, final Object cond, final int hc, final int lev,
             final INode<K, V> parent, final Gen startgen, final TrieMap<K, V> ct) {
-        final MainNode<K, V> m = gcasRead(ct);
+        final var m = gcasRead(ct);
 
         if (m instanceof CNode) {
-            final CNode<K, V> cn = (CNode<K, V>) m;
+            final var cn = (CNode<K, V>) m;
             final int idx = hc >>> lev & 0x1f;
             final int bmp = cn.bitmap;
             final int flag = 1 << idx;
@@ -460,25 +434,23 @@ final class INode<K, V> extends BasicNode {
             }
 
             final int pos = Integer.bitCount(bmp & flag - 1);
-            final BasicNode sub = cn.array[pos];
+            final var sub = cn.array[pos];
             final Result<V> res;
             if (sub instanceof INode) {
                 @SuppressWarnings("unchecked")
-                final INode<K, V> in = (INode<K, V>) sub;
+                final var in = (INode<K, V>) sub;
                 if (startgen == in.gen) {
                     res = in.recRemove(key, cond, hc, lev + LEVEL_BITS, this, startgen, ct);
+                } else if (gcas(cn, cn.renewed(startgen, ct), ct)) {
+                    res = recRemove(key, cond, hc, lev, parent, startgen, ct);
                 } else {
-                    if (gcas(cn, cn.renewed(startgen, ct), ct)) {
-                        res = recRemove(key, cond, hc, lev, parent, startgen, ct);
-                    } else {
-                        res = null;
-                    }
+                    res = null;
                 }
             } else if (sub instanceof SNode) {
                 @SuppressWarnings("unchecked")
-                final SNode<K, V> sn = (SNode<K, V>) sub;
+                final var sn = (SNode<K, V>) sub;
                 if (sn.hc == hc && key.equals(sn.key) && (cond == null || cond.equals(sn.value))) {
-                    final MainNode<K, V> ncn = cn.removedAt(pos, flag, gen).toContracted(lev);
+                    final var ncn = cn.removedAt(pos, flag, gen).toContracted(lev);
                     if (gcas(cn, ncn, ct)) {
                         res = Result.of(sn);
                     } else {
@@ -497,7 +469,7 @@ final class INode<K, V> extends BasicNode {
 
             if (parent != null) {
                 // never tomb at root
-                final MainNode<K, V> n = gcasRead(ct);
+                final var n = gcasRead(ct);
                 if (n instanceof TNode) {
                     cleanParent(n, parent, ct, hc, lev, startgen);
                 }
@@ -508,8 +480,8 @@ final class INode<K, V> extends BasicNode {
             clean(parent, ct, lev - LEVEL_BITS);
             return null;
         } else if (m instanceof LNode) {
-            final LNode<K, V> ln = (LNode<K, V>) m;
-            final LNodeEntry<K, V> entry = ln.get(key);
+            final var ln = (LNode<K, V>) m;
+            final var entry = ln.get(key);
             if (entry == null) {
                 // Key was not found, hence no modification is needed
                 return Result.empty();
@@ -529,13 +501,13 @@ final class INode<K, V> extends BasicNode {
     private void cleanParent(final Object nonlive, final INode<K, V> parent, final TrieMap<K, V> ct, final int hc,
             final int lev, final Gen startgen) {
         while (true) {
-            final MainNode<K, V> pm = parent.gcasRead(ct);
+            final var pm = parent.gcasRead(ct);
             if (!(pm instanceof CNode)) {
                 // parent is no longer a cnode, we're done
                 return;
             }
 
-            final CNode<K, V> cn = (CNode<K, V>) pm;
+            final var cn = (CNode<K, V>) pm;
             final int idx = hc >>> lev - LEVEL_BITS & 0x1f;
             final int bmp = cn.bitmap;
             final int flag = 1 << idx;
@@ -545,10 +517,10 @@ final class INode<K, V> extends BasicNode {
             }
 
             final int pos = Integer.bitCount(bmp & flag - 1);
-            final BasicNode sub = cn.array[pos];
+            final var sub = cn.array[pos];
             if (sub == this && nonlive instanceof TNode) {
-                final TNode<?, ?> tn = (TNode<?, ?>) nonlive;
-                final MainNode<K, V> ncn = cn.updatedAt(pos, tn.copyUntombed(), gen).toContracted(lev - LEVEL_BITS);
+                final var tn = (TNode<?, ?>) nonlive;
+                final var ncn = cn.updatedAt(pos, tn.copyUntombed(), gen).toContracted(lev - LEVEL_BITS);
                 if (!parent.gcas(cn, ncn, ct)) {
                     if (ct.readRoot().gen == startgen) {
                         // Tail recursion: cleanParent(nonlive, parent, ct, hc, lev, startgen);
@@ -561,9 +533,9 @@ final class INode<K, V> extends BasicNode {
     }
 
     private void clean(final INode<K, V> nd, final TrieMap<K, V> ct, final int lev) {
-        final MainNode<K, V> m = nd.gcasRead(ct);
+        final var m = nd.gcasRead(ct);
         if (m instanceof CNode) {
-            final CNode<K, V> cn = (CNode<K, V>) m;
+            final var cn = (CNode<K, V>) m;
             nd.gcas(cn, cn.toCompressed(ct, lev, gen), ct);
         }
     }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -36,16 +36,13 @@ final class LNode<K, V> extends MainNode<K, V> {
     MainNode<K, V> removeChild(final LNodeEntry<K, V> entry, final int hc) {
         // While remove() can return null, that case will never happen here, as we are starting off with two entries
         // so we cannot observe a null return here.
-        final LNodeEntries<K, V> map = VerifyException.throwIfNull(entries.remove(entry));
+        final var map = VerifyException.throwIfNull(entries.remove(entry));
 
         // If the returned LNode would have only one element, we turn it into a TNode, hence above null return from
         // remove() can never happen.
-        if (size == 2) {
+        return size != 2 ? new LNode<>(map, size - 1)
             // create it tombed so that it gets compressed on subsequent accesses
-            return new TNode<>(map.getKey(), map.getValue(), hc);
-        }
-
-        return new LNode<>(map, size - 1);
+            : new TNode<>(map.getKey(), map.getValue(), hc);
     }
 
     MainNode<K, V> replaceChild(final LNodeEntry<K, V> entry, final V value) {

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
@@ -75,7 +75,7 @@ abstract class LNodeEntries<K, V> extends LNodeEntry<K, V> {
 
     final LNodeEntry<K, V> findEntry(final K key) {
         // We do not perform recursion on purpose here, so we do not run out of stack if the key hashing fails.
-        LNodeEntries<K, V> entry = this;
+        var entry = this;
         do {
             if (key.equals(entry.getKey())) {
                 return entry;
@@ -105,10 +105,10 @@ abstract class LNodeEntries<K, V> extends LNodeEntry<K, V> {
         // This will result in a list with a long tail, i.e last entry storing explicit null. Overhead is amortized
         // against the number of entries. We do not retain chains shorter than two, so the worst-case overhead is
         // half-a-reference for an entry.
-        final Multiple<K, V> ret = new Multiple<>(this);
+        final var ret = new Multiple<>(this);
 
-        Multiple<K, V> last = ret;
-        LNodeEntries<K, V> cur = next();
+        var last = ret;
+        var cur = next();
         while (cur != null) {
             // We cannot use equals() here, as it is wired to key equality and we must never compare entries based on
             // that property. This method is intended to remove a known reference, so identity is what we want.
@@ -117,7 +117,7 @@ abstract class LNodeEntries<K, V> extends LNodeEntry<K, V> {
                 return ret;
             }
 
-            final Multiple<K, V> tmp = new Multiple<>(cur);
+            final var tmp = new Multiple<>(cur);
             last.next = tmp;
             last = tmp;
             cur = cur.next();

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
@@ -47,12 +47,12 @@ final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
             return false;
         }
 
-        final Entry<?, ?> e = (Entry<?, ?>) o;
-        final Object key = e.getKey();
+        final var e = (Entry<?, ?>) o;
+        final var key = e.getKey();
         if (key == null) {
             return false;
         }
-        final Object value = e.getValue();
+        final var value = e.getValue();
         if (value == null) {
             return false;
         }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
@@ -98,7 +98,7 @@ final class MutableIterator<K, V> extends AbstractIterator<K, V> {
          */
         @Override
         public V setValue(final V value) {
-            final V ret = getValue();
+            final var ret = getValue();
             map.put(getKey(), value);
             newValue = value;
             return ret;

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -65,20 +65,20 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
 
     @Override
     public V put(final K key, final V value) {
-        final K k = requireNonNull(key);
+        final var k = requireNonNull(key);
         return insertifhc(k, computeHash(k), requireNonNull(value), null).orNull();
     }
 
     @Override
     public V putIfAbsent(final K key, final V value) {
-        final K k = requireNonNull(key);
+        final var k = requireNonNull(key);
         return insertifhc(k, computeHash(k), requireNonNull(value), ABSENT).orNull();
     }
 
     @Override
     public V remove(final Object key) {
         @SuppressWarnings("unchecked")
-        final K k = (K) requireNonNull(key);
+        final var k = (K) requireNonNull(key);
         return removehc(k, null, computeHash(k)).orNull();
     }
 
@@ -87,19 +87,19 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @Override
     public boolean remove(final Object key, final Object value) {
         @SuppressWarnings("unchecked")
-        final K k = (K) requireNonNull(key);
+        final var k = (K) requireNonNull(key);
         return removehc(k, requireNonNull(value), computeHash(k)).isPresent();
     }
 
     @Override
     public boolean replace(final K key, final V oldValue, final V newValue) {
-        final K k = requireNonNull(key);
+        final var k = requireNonNull(key);
         return insertifhc(k, computeHash(k), requireNonNull(newValue), requireNonNull(oldValue)).isPresent();
     }
 
     @Override
     public V replace(final K key, final V value) {
-        final K k = requireNonNull(key);
+        final var k = requireNonNull(key);
         return insertifhc(k, computeHash(k), requireNonNull(value), PRESENT).orNull();
     }
 
@@ -152,7 +152,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @Override
     @SuppressWarnings("unchecked")
     INode<K, V> rdcssReadRoot(final boolean abort) {
-        final Object r = /* READ */ root;
+        final var r = /* READ */ root;
         if (r instanceof INode) {
             return (INode<K, V>) r;
         }
@@ -167,7 +167,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     }
 
     private static <K, V> INode<K, V> newRootNode() {
-        final Gen gen = new Gen();
+        final var gen = new Gen();
         return new INode<>(gen, new CNode<>(gen));
     }
 
@@ -204,7 +204,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     }
 
     private boolean rdcssRoot(final INode<K, V> ov, final MainNode<K, V> expectedmain, final INode<K, V> nv) {
-        final RDCSS_Descriptor<K, V> desc = new RDCSS_Descriptor<>(ov, expectedmain, nv);
+        final var desc = new RDCSS_Descriptor<>(ov, expectedmain, nv);
         if (casRoot(ov, desc)) {
             rdcssComplete(false);
             return /* READ */desc.committed;
@@ -216,16 +216,16 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @SuppressWarnings("unchecked")
     private INode<K, V> rdcssComplete(final boolean abort) {
         while (true) {
-            final Object r = /* READ */ root;
+            final var r = /* READ */ root;
             if (r instanceof INode) {
                 return (INode<K, V>) r;
             }
 
             verifyRootDescriptor(r);
-            final RDCSS_Descriptor<K, V> desc = (RDCSS_Descriptor<K, V>) r;
-            final INode<K, V> ov = desc.old;
-            final MainNode<K, V> exp = desc.expectedmain;
-            final INode<K, V> nv = desc.nv;
+            final var desc = (RDCSS_Descriptor<K, V>) r;
+            final var ov = desc.old;
+            final var exp = desc.expectedmain;
+            final var nv = desc.nv;
 
             if (abort) {
                 if (casRoot(desc, ov)) {
@@ -236,7 +236,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 continue;
             }
 
-            final MainNode<K, V> oldmain = ov.gcasRead(this);
+            final var oldmain = ov.gcasRead(this);
             if (oldmain == exp) {
                 if (casRoot(desc, nv)) {
                     desc.committed = true;
@@ -267,6 +267,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         final MainNode<K, V> expectedmain;
         final INode<K, V> nv;
 
+        // FIXME: use VarHandle for access?
         volatile boolean committed = false;
 
         RDCSS_Descriptor(final INode<K, V> old, final MainNode<K, V> expectedmain, final INode<K, V> nv) {

--- a/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
@@ -25,7 +25,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.ObjectStreamException;
 import java.io.StreamCorruptedException;
-import java.util.Map.Entry;
 
 /**
  * External serialization object for use with TrieMap objects. This hides the implementation details, such as object
@@ -54,7 +53,7 @@ final class SerializationProxy implements Externalizable {
     public void writeExternal(final ObjectOutput out) throws IOException {
         out.writeObject(Equivalence.Equals.INSTANCE);
         out.writeInt(map.size());
-        for (Entry<Object, Object> e : map.entrySet()) {
+        for (var e : map.entrySet()) {
             out.writeObject(e.getKey());
             out.writeObject(e.getValue());
         }
@@ -63,12 +62,12 @@ final class SerializationProxy implements Externalizable {
 
     @Override
     public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
-        final Object eqObj = in.readObject();
+        final var eqObj = in.readObject();
         if (!(eqObj instanceof Equivalence)) {
             throw new InvalidObjectException("Expected Equivalence object instead of " + eqObj);
         }
 
-        final MutableTrieMap<Object, Object> tmp = new MutableTrieMap<>();
+        final var tmp = new MutableTrieMap<>();
         final int size = in.readInt();
         if (size < 0) {
             throw new StreamCorruptedException("Expected non-negative size instead of " + size);

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -109,7 +109,7 @@ public abstract class TrieMap<K, V> extends AbstractMap<K, V> implements Concurr
     @Override
     public final V get(final Object key) {
         @SuppressWarnings("unchecked")
-        final K k = (K) requireNonNull(key);
+        final var k = (K) requireNonNull(key);
         return lookuphc(k, computeHash(k));
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
@@ -227,7 +227,7 @@ public abstract class TrieSet<E> implements Set<E>, Serializable {
 
         @Override
         public void writeExternal(final ObjectOutput out) throws IOException {
-            final ImmutableTrieSet<?> snap = set.immutableSnapshot();
+            final var snap = set.immutableSnapshot();
             out.writeBoolean(set instanceof ImmutableTrieSet);
             out.writeInt(snap.size());
             for (Object e : snap) {
@@ -243,7 +243,7 @@ public abstract class TrieSet<E> implements Set<E>, Serializable {
                 throw new StreamCorruptedException("Expected non-negative size instead of " + size);
             }
 
-            final MutableTrieSet<Object> read = TrieSet.create();
+            final var read = TrieSet.create();
             for (int i = 0; i < size; ++i) {
                 read.add(in.readObject());
             }


### PR DESCRIPTION
Use variable type inference where possible. Also simplify returns. Fixes #92.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>