### PR TITLE
Bump odlparent to 12.0.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>10.0.6</version>
+        <version>12.0.4</version>
         <relativePath />
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>10.0.6</version>
+        <version>12.0.4</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>10.0.6</version>
+        <version>12.0.4</version>
         <relativePath />
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>10.0.6</version>
+        <version>12.0.4</version>
         <relativePath />
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bundle-parent</artifactId>
-        <version>10.0.6</version>
+        <version>12.0.4</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Update odlparent to latest release, switching to require Java 17. Detailed release notes are available at
https://github.com/opendaylight/odlparent/blob/master/docs/NEWS.rst#version-1204