### PR TITLE
Enable repository cache in codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: maven
 
     - name: Build with Maven
       run: mvn --batch-mode --errors --show-version -Pq clean package


### PR DESCRIPTION
There is no point in downloading things over and over again, cache them.