### PR TITLE
Remove deploy/install plugin configuration

### DIFF
--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -33,6 +33,11 @@
     <description>Artifact for validating the contents of BOM</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.install.skip>true</maven.install.skip>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -58,25 +63,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -89,7 +75,7 @@
         <developerConnection>scm:git:https://github.com/PantheonTechnologies/triemap.git</developerConnection>
         <url>https://github.com/PantheonTechnologies/triemap</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
     <developers>
         <developer>
             <id>rovarga</id>


### PR DESCRIPTION
The plugin configuration is just a long-winded way of achieving what can easily be done through properties. Define two properties only.