### PR TITLE
Rename EntryUtil methods

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/EntryUtil.java
@@ -30,26 +30,21 @@ final class EntryUtil {
     /**
      * Utility implementing {@link Entry#equals(Object)}.
      */
-    static boolean equal(final Object obj, final Object key, final Object value) {
-        if (!(obj instanceof Entry)) {
-            return false;
-        }
-
-        final Entry<?, ?> entry = (Entry<?, ?>)obj;
-        return key.equals(entry.getKey()) && value.equals(entry.getValue());
+    static boolean entryEquals(final Object obj, final Object key, final Object value) {
+        return obj instanceof Entry<?, ?> entry && key.equals(entry.getKey()) && value.equals(entry.getValue());
     }
 
     /**
      * Utility implementing {@link Entry#hashCode()}.
      */
-    static int hash(final Object key, final Object value) {
+    static int entryHashCode(final Object key, final Object value) {
         return key.hashCode() ^ value.hashCode();
     }
 
     /**
      * Utility implementing {@link Entry#toString()}.
      */
-    static String string(final Object key, final Object value) {
+    static String entryToString(final Object key, final Object value) {
         return key + "=" + value;
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
@@ -59,17 +59,17 @@ abstract class LNodeEntry<K, V> implements Entry<K, V> {
 
     @Override
     public final int hashCode() {
-        return EntryUtil.hash(key, value);
+        return EntryUtil.entryHashCode(key, value);
     }
 
     @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public final boolean equals(final Object obj) {
-        return EntryUtil.equal(obj, key, value);
+        return EntryUtil.entryEquals(obj, key, value);
     }
 
     @Override
     public final String toString() {
-        return EntryUtil.string(key, value);
+        return EntryUtil.entryToString(key, value);
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
@@ -106,18 +106,18 @@ final class MutableIterator<K, V> extends AbstractIterator<K, V> {
 
         @Override
         public int hashCode() {
-            return EntryUtil.hash(getKey(), getValue());
+            return EntryUtil.entryHashCode(getKey(), getValue());
         }
 
         @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
         @Override
         public boolean equals(final Object obj) {
-            return EntryUtil.equal(obj, getKey(), getValue());
+            return EntryUtil.entryEquals(obj, getKey(), getValue());
         }
 
         @Override
         public String toString() {
-            return EntryUtil.string(getKey(), getValue());
+            return EntryUtil.entryToString(getKey(), getValue());
         }
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -49,17 +49,17 @@ final class SNode<K, V> extends BasicNode implements EntryNode<K, V> {
 
     @Override
     public int hashCode() {
-        return EntryUtil.hash(key, value);
+        return EntryUtil.entryHashCode(key, value);
     }
 
     @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public boolean equals(final Object obj) {
-        return EntryUtil.equal(obj, key, value);
+        return EntryUtil.entryEquals(obj, key, value);
     }
 
     @Override
     public String toString() {
-        return EntryUtil.string(key, value);
+        return EntryUtil.entryToString(key, value);
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/TNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TNode.java
@@ -54,17 +54,17 @@ final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
 
     @Override
     public int hashCode() {
-        return EntryUtil.hash(key, value);
+        return EntryUtil.entryHashCode(key, value);
     }
 
     @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public boolean equals(final Object obj) {
-        return EntryUtil.equal(obj, key, value);
+        return EntryUtil.entryEquals(obj, key, value);
     }
 
     @Override
     public String toString() {
-        return EntryUtil.string(key, value);
+        return EntryUtil.entryToString(key, value);
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/EntryUtilTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/EntryUtilTest.java
@@ -27,25 +27,25 @@ class EntryUtilTest {
     void testEqual() {
         final Object key = new Object();
         final Object value = new Object();
-        assertFalse(EntryUtil.equal(null, key, value));
-        assertFalse(EntryUtil.equal(key, key, value));
+        assertFalse(EntryUtil.entryEquals(null, key, value));
+        assertFalse(EntryUtil.entryEquals(key, key, value));
 
         final var entry = Map.entry(key, value);
-        assertTrue(EntryUtil.equal(entry, key, value));
-        assertFalse(EntryUtil.equal(entry, value, value));
-        assertFalse(EntryUtil.equal(entry, key, key));
+        assertTrue(EntryUtil.entryEquals(entry, key, value));
+        assertFalse(EntryUtil.entryEquals(entry, value, value));
+        assertFalse(EntryUtil.entryEquals(entry, key, key));
     }
 
     @Test
     void testHash() {
         final Object key = new Object();
         final Object value = new Object();
-        assertEquals(key.hashCode() ^ value.hashCode(), EntryUtil.hash(key, value));
+        assertEquals(key.hashCode() ^ value.hashCode(), EntryUtil.entryHashCode(key, value));
     }
 
     @Test
     void testString() {
-        assertEquals("foo=bar", EntryUtil.string("foo", "bar"));
+        assertEquals("foo=bar", EntryUtil.entryToString("foo", "bar"));
     }
 
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
@@ -36,11 +36,11 @@ class LNodeEntryTest {
 
     @Test
     void testEntryUtil() {
-        assertEquals(EntryUtil.hash(KEY1, VALUE), entry.hashCode());
-        assertEquals(EntryUtil.string(KEY1, VALUE), entry.toString());
+        assertEquals(EntryUtil.entryHashCode(KEY1, VALUE), entry.hashCode());
+        assertEquals(EntryUtil.entryToString(KEY1, VALUE), entry.toString());
 
         final var testEntry = Map.entry(KEY1, VALUE);
-        assertEquals(EntryUtil.equal(testEntry, KEY1, VALUE), entry.equals(testEntry));
+        assertEquals(EntryUtil.entryEquals(testEntry, KEY1, VALUE), entry.equals(testEntry));
     }
 
     @Test

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableIteratorTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableIteratorTest.java
@@ -39,11 +39,11 @@ class MutableIteratorTest {
     void testEntryUtil() {
         final var entry = it.next();
 
-        assertEquals(EntryUtil.hash(KEY, VALUE), entry.hashCode());
-        assertEquals(EntryUtil.string(KEY, VALUE), entry.toString());
+        assertEquals(EntryUtil.entryHashCode(KEY, VALUE), entry.hashCode());
+        assertEquals(EntryUtil.entryToString(KEY, VALUE), entry.toString());
 
         final var testEntry = Map.entry(KEY, VALUE);
-        assertEquals(EntryUtil.equal(testEntry, KEY, VALUE), entry.equals(entry));
+        assertEquals(EntryUtil.entryEquals(testEntry, KEY, VALUE), entry.equals(entry));
     }
 
     @Test

--- a/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
@@ -44,10 +44,10 @@ class SNodeTest {
 
     @Test
     void testEntryUtil() {
-        assertEquals(EntryUtil.hash(KEY, VALUE), snode.hashCode());
-        assertEquals(EntryUtil.string(KEY, VALUE), snode.toString());
+        assertEquals(EntryUtil.entryHashCode(KEY, VALUE), snode.hashCode());
+        assertEquals(EntryUtil.entryToString(KEY, VALUE), snode.toString());
 
         final var entry = Map.entry(KEY, VALUE);
-        assertEquals(EntryUtil.equal(entry, KEY, VALUE), snode.equals(entry));
+        assertEquals(EntryUtil.entryEquals(entry, KEY, VALUE), snode.equals(entry));
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
@@ -50,10 +50,10 @@ class TNodeTest {
 
     @Test
     void testEntryUtil() {
-        assertEquals(EntryUtil.hash(KEY, VALUE), tnode.hashCode());
-        assertEquals(EntryUtil.string(KEY, VALUE), tnode.toString());
+        assertEquals(EntryUtil.entryHashCode(KEY, VALUE), tnode.hashCode());
+        assertEquals(EntryUtil.entryToString(KEY, VALUE), tnode.toString());
 
         final var entry = Map.entry(KEY, VALUE);
-        assertEquals(EntryUtil.equal(entry, KEY, VALUE), tnode.equals(entry));
+        assertEquals(EntryUtil.entryEquals(entry, KEY, VALUE), tnode.equals(entry));
     }
 }


### PR DESCRIPTION
Sonar does not like naming here, prefix methods with 'entry'. Also use an instanceof pattern to make entryEquals() simpler.