### PR TITLE
Seal BasicNode hierarchy

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/BasicNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/BasicNode.java
@@ -15,6 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-abstract class BasicNode {
+abstract sealed class BasicNode permits MainNode, INode, SNode {
 
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
@@ -18,7 +18,7 @@ package tech.pantheon.triemap;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-abstract class MainNode<K, V> extends BasicNode {
+abstract sealed class MainNode<K, V> extends BasicNode permits CNode, FailedNode, LNode, TNode {
     static final int NO_SIZE = -1;
 
     private static final VarHandle PREV;
@@ -34,7 +34,7 @@ abstract class MainNode<K, V> extends BasicNode {
     private volatile MainNode<K, V> prev;
 
     MainNode() {
-        this.prev = null;
+        prev = null;
     }
 
     MainNode(final MainNode<K, V> prev) {

--- a/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/FailedNodeTest.java
@@ -18,22 +18,11 @@ package tech.pantheon.triemap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class FailedNodeTest {
-    @Mock
-    private MainNode<Object, Object> main;
-    private FailedNode<Object, Object> failed;
-
-    @BeforeEach
-    void before() {
-        failed = new FailedNode<>(main);
-    }
+    private final TNode<Object, Object> tnode = new TNode<>(new Object(), new Object(), 123);
+    private final FailedNode<Object, Object> failed = new FailedNode<>(tnode);
 
     @Test
     void testSize() {
@@ -47,6 +36,6 @@ class FailedNodeTest {
 
     @Test
     void testToString() {
-        assertEquals("FailedNode(" + main + ")", failed.toString());
+        assertEquals("FailedNode(" + tnode + ")", failed.toString());
     }
 }


### PR DESCRIPTION
The set of node implementations is very much fixed, make sure we express that through sealing the hierarchy. Also use TNode in FailedNodeTest, as we cannot mock MainNode now.