### PR TITLE
Add @java.io.Serial annotations

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
@@ -26,9 +26,11 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
  */
 @NonNullByDefault
 abstract class Equivalence implements Serializable {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     static final class Equals extends Equivalence {
+        @java.io.Serial
         private static final long serialVersionUID = 1L;
 
         static final Equals INSTANCE = new Equals();
@@ -39,5 +41,6 @@ abstract class Equivalence implements Serializable {
         }
     }
 
+    @java.io.Serial
     abstract Object readResolve();
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -31,6 +31,7 @@ import java.util.function.Function;
  * @param <V> the type of mapped values
  */
 public final class ImmutableTrieMap<K, V> extends TrieMap<K, V> {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieSet.java
@@ -22,6 +22,7 @@ package tech.pantheon.triemap;
  * @author Robert Varga
  */
 public final class ImmutableTrieSet<E> extends TrieSet<E> {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     ImmutableTrieSet(final ImmutableTrieMap<E, Boolean> map) {

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.annotation.NonNull;
  * @param <V> the type of mapped values
  */
 public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private static final VarHandle ROOT;

--- a/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
@@ -33,6 +33,7 @@ import java.io.StreamCorruptedException;
  * @author Robert Varga
  */
 final class SerializationProxy implements Externalizable {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private transient TrieMap<Object, Object> map;
@@ -80,6 +81,7 @@ final class SerializationProxy implements Externalizable {
         map = in.readBoolean() ? tmp.immutableSnapshot() : tmp;
     }
 
+    @java.io.Serial
     private Object readResolve() throws ObjectStreamException {
         if (map == null) {
             throw new NotActiveException();

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -18,7 +18,6 @@ package tech.pantheon.triemap;
 import static java.util.Objects.requireNonNull;
 import static tech.pantheon.triemap.LookupResult.RESTART;
 
-import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.Set;
@@ -37,6 +36,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,V>, Serializable
         permits ImmutableTrieMap, MutableTrieMap {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     private transient AbstractEntrySet<K, V> entrySet;
@@ -184,7 +184,8 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         return hash;
     }
 
-    final Object writeReplace() throws ObjectStreamException {
+    @java.io.Serial
+    final Object writeReplace() {
         return new SerializationProxy(immutableSnapshot(), isReadOnly());
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
  * @param <E> the type of elements maintained by this set
  */
 public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits ImmutableTrieSet, MutableTrieSet {
+    @java.io.Serial
     private static final long serialVersionUID = 0L;
 
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")
@@ -203,6 +204,7 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
         return set.toString();
     }
 
+    @java.io.Serial
     final Object writeReplace() {
         return new SerializedForm(this);
     }
@@ -212,6 +214,7 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
     }
 
     private static final class SerializedForm implements Externalizable {
+        @java.io.Serial
         private static final long serialVersionUID = 0L;
 
         private transient TrieSet<?> set;
@@ -251,6 +254,7 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
             set = readOnly ? read.immutableSnapshot() : read;
         }
 
+        @java.io.Serial
         Object readResolve() {
             return set;
         }

--- a/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/VerifyException.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 final class VerifyException extends RuntimeException {
+    @java.io.Serial
     private static final long serialVersionUID = 1L;
 
     VerifyException(final @NonNull String message) {


### PR DESCRIPTION
We have a ton of serialization-related methods and fields, annotate them
with @Serial to improve validation.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
