### PR TITLE
Improve {Abstract,Mutable}KeySet.iterator() memory overhead

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
@@ -78,18 +78,24 @@ abstract class AbstractKeySet<K> extends AbstractSet<K> {
     abstract int spliteratorCharacteristics();
 
     final Iterator<K> immutableIterator() {
-        return new Iterator<K>() {
-            private final ImmutableIterator<K, ?> itr = map().immutableIterator();
+        return new Itr<>(map().immutableIterator());
+    }
 
-            @Override
-            public boolean hasNext() {
-                return itr.hasNext();
-            }
+    private static final class Itr<K> implements Iterator<K> {
+        private final ImmutableIterator<K, ?> delegate;
 
-            @Override
-            public K next() {
-                return itr.next().getKey();
-            }
-        };
+        Itr(final ImmutableIterator<K, ?> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public K next() {
+            return delegate.next().getKey();
+        }
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
@@ -32,24 +32,7 @@ final class MutableKeySet<K> extends AbstractKeySet<K> {
 
     @Override
     public Iterator<K> iterator() {
-        return new Iterator<K>() {
-            private final AbstractIterator<K, ?> itr = map().iterator();
-
-            @Override
-            public boolean hasNext() {
-                return itr.hasNext();
-            }
-
-            @Override
-            public K next() {
-                return itr.next().getKey();
-            }
-
-            @Override
-            public void remove() {
-                itr.remove();
-            }
-        };
+        return new Itr<>(map().iterator());
     }
 
     @Override
@@ -66,5 +49,28 @@ final class MutableKeySet<K> extends AbstractKeySet<K> {
     @Override
     int spliteratorCharacteristics() {
         return Spliterator.DISTINCT | Spliterator.CONCURRENT | Spliterator.NONNULL;
+    }
+
+    private static final class Itr<K> implements Iterator<K> {
+        private final AbstractIterator<K, ?> delegate;
+
+        Itr(final AbstractIterator<K, ?> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public K next() {
+            return delegate.next().getKey();
+        }
+
+        @Override
+        public void remove() {
+            delegate.remove();
+        }
     }
 }


### PR DESCRIPTION
Do not use an anonymous class, but rather a dedicated nested class, which reduces the need to capture 'this', which we do not really need. This translates to 8 bytes saved on typical use.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
(cherry picked from commit 9962d4e05bea377eb90eb2a71c27d717aedb7dce)