### PR TITLE
Bump released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The prebuilt binaries of the library are available from Maven central. Please us
     <dependency>
         <groupId>tech.pantheon.triemap</groupId>
         <artifactId>triemap</artifactId>
-        <version>1.0.6</version>
+        <version>1.2.2</version>
     </dependency>
 ```
 


### PR DESCRIPTION
We have triemap-1.2.2 out there, fix the reference.