### PR TITLE
Bump referece to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The prebuilt binaries of the library are available from Maven central. Please us
     <dependency>
         <groupId>tech.pantheon.triemap</groupId>
         <artifactId>triemap</artifactId>
-        <version>1.2.1</version>
+        <version>1.3.0</version>
     </dependency>
 ```
 


### PR DESCRIPTION
Java 17-requiring version 1.3.0 is the latest, document that fact.