### PR TITLE
Improve MutableTrieMap.root

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -24,7 +24,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import org.eclipse.jdt.annotation.Nullable;
 
-final class INode<K, V> extends BasicNode {
+final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
     private static final VarHandle MAINNODE;
 
     static {


### PR DESCRIPTION
Add MutableTrieMap.Root marker interface to make it explicit that only INode or RDCSS_Descriptor can be a valid root of MutableTrieMap.