### PR TITLE
Remove sonar config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,6 @@
     <description>Project top-level aggregator POM</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
-    <properties>
-        <sonar.jacoco.reportPaths>${project.build.directory}/code-coverage/jacoco.exec</sonar.jacoco.reportPaths>
-        <sonar.jacoco.itReportPaths>${project.build.directory}/code-coverage/jacoco-it.exec</sonar.jacoco.itReportPaths>
-    </properties>
-
     <modules>
         <module>bom</module>
         <module>dependency-check</module>


### PR DESCRIPTION
Defaults from upstream are okay and this only elicits a warning. Remove the properties.