### PR TITLE
Share iterator implementation for keySet()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractKeySet.java
@@ -19,9 +19,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.AbstractSet;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * Abstract base class for key set views of a TrieMap.
@@ -30,15 +30,12 @@ import java.util.Spliterators;
  *
  * @param <K> the type of keys
  */
-abstract sealed class AbstractKeySet<K> extends AbstractSet<K> permits ImmutableKeySet, MutableKeySet {
-    private final TrieMap<K, ?> map;
+abstract sealed class AbstractKeySet<K, M extends TrieMap<K, ?>> extends AbstractSet<K>
+        permits ImmutableKeySet, MutableKeySet {
+    final @NonNull M map;
 
-    AbstractKeySet(final TrieMap<K, ?> map) {
+    AbstractKeySet(final M map) {
         this.map = requireNonNull(map);
-    }
-
-    final TrieMap<K, ?> map() {
-        return map;
     }
 
     @Override
@@ -75,27 +72,12 @@ abstract sealed class AbstractKeySet<K> extends AbstractSet<K> permits Immutable
         return Spliterators.spliterator(immutableIterator(), Long.MAX_VALUE, spliteratorCharacteristics());
     }
 
+    @Override
+    public abstract KeySetIterator<K> iterator();
+
+    final @NonNull KeySetIterator<K> immutableIterator() {
+        return new KeySetIterator<>(map.immutableIterator());
+    }
+
     abstract int spliteratorCharacteristics();
-
-    final Iterator<K> immutableIterator() {
-        return new Itr<>(map().immutableIterator());
-    }
-
-    private static final class Itr<K> implements Iterator<K> {
-        private final ImmutableIterator<K, ?> delegate;
-
-        Itr(final ImmutableIterator<K, ?> delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return delegate.hasNext();
-        }
-
-        @Override
-        public K next() {
-            return delegate.next().getKey();
-        }
-    }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableKeySet.java
@@ -18,7 +18,6 @@ package tech.pantheon.triemap;
 import static tech.pantheon.triemap.ImmutableTrieMap.unsupported;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Spliterator;
 
 /**
@@ -28,13 +27,13 @@ import java.util.Spliterator;
  *
  * @param <K> the type of keys
  */
-final class ImmutableKeySet<K> extends AbstractKeySet<K> {
-    ImmutableKeySet(final TrieMap<K, ?> map) {
+final class ImmutableKeySet<K> extends AbstractKeySet<K, ImmutableTrieMap<K, ?>> {
+    ImmutableKeySet(final ImmutableTrieMap<K, ?> map) {
         super(map);
     }
 
     @Override
-    public Iterator<K> iterator() {
+    public KeySetIterator<K> iterator() {
         return immutableIterator();
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/KeySetIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/KeySetIterator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 PANTHEON.tech, s.r.o. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package tech.pantheon.triemap;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+
+/**
+ * Iterator given out by {@link AbstractKeySet} implementations.
+ */
+final class KeySetIterator<K> implements Iterator<K> {
+    private final AbstractIterator<K, ?> delegate;
+
+    KeySetIterator(final AbstractIterator<K, ?> delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public K next() {
+        return delegate.next().getKey();
+    }
+
+    @Override
+    public void remove() {
+        delegate.remove();
+    }
+}

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableKeySet.java
@@ -15,7 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import java.util.Iterator;
 import java.util.Spliterator;
 
 /**
@@ -25,52 +24,29 @@ import java.util.Spliterator;
  *
  * @param <K> the type of keys
  */
-final class MutableKeySet<K> extends AbstractKeySet<K> {
+final class MutableKeySet<K> extends AbstractKeySet<K, MutableTrieMap<K, ?>> {
     MutableKeySet(final MutableTrieMap<K, ?> map) {
         super(map);
     }
 
     @Override
-    public Iterator<K> iterator() {
-        return new Itr<>(map().iterator());
+    public KeySetIterator<K> iterator() {
+        return new KeySetIterator<>(map.iterator());
     }
 
     @Override
     public void clear() {
-        map().clear();
+        map.clear();
     }
 
     @Override
     @SuppressWarnings("checkstyle:parameterName")
     public boolean remove(final Object o) {
-        return map().remove(o) != null;
+        return map.remove(o) != null;
     }
 
     @Override
     int spliteratorCharacteristics() {
         return Spliterator.DISTINCT | Spliterator.CONCURRENT | Spliterator.NONNULL;
-    }
-
-    private static final class Itr<K> implements Iterator<K> {
-        private final AbstractIterator<K, ?> delegate;
-
-        Itr(final AbstractIterator<K, ?> delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public boolean hasNext() {
-            return delegate.hasNext();
-        }
-
-        @Override
-        public K next() {
-            return delegate.next().getKey();
-        }
-
-        @Override
-        public void remove() {
-            delegate.remove();
-        }
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -42,7 +42,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
     private transient AbstractEntrySet<K, V> entrySet;
     // Note: AbstractMap.keySet is something we do not have access to. At some point we should just not subclass
     //       AbstractMap and lower our memory footprint.
-    private transient AbstractKeySet<K> theKeySet;
+    private transient AbstractKeySet<K, ?> theKeySet;
 
     TrieMap() {
         // Hidden on purpose
@@ -105,7 +105,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     @Override
     public final Set<K> keySet() {
-        final AbstractKeySet<K> ret;
+        final AbstractKeySet<K, ?> ret;
         return (ret = theKeySet) != null ? ret : (theKeySet = createKeySet());
     }
 
@@ -144,7 +144,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     abstract AbstractEntrySet<K, V> createEntrySet();
 
-    abstract AbstractKeySet<K> createKeySet();
+    abstract AbstractKeySet<K, ?> createKeySet();
 
     abstract boolean isReadOnly();
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
@@ -47,7 +47,7 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
     private final transient TrieMap<E, Boolean> map;
     // Cached map keyset view, so we do not re-checking it all over
     @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification = "Handled through writeReplace")
-    private final transient AbstractKeySet<E> set;
+    private final transient AbstractKeySet<E, ?> set;
 
     TrieSet(final TrieMap<E, Boolean> map) {
         this.map = requireNonNull(map);


### PR DESCRIPTION
Both AbstractKeySet implementations end up doing essestially the same
thing: transform AbstractIterator on getKey().

Rather than doing that, introduce KeySetIterator and share it for both
implementations. For Iterator.remove() we delegate to AbstractIterator,
which does the right thing anyway.

The way go about this is that we capture AbstractKeySet's TrieMap type,
which is now a generic type argument. Doing that renders
AbstractKeySet.map() moot, as we can just expose the field.

This in turn converts an INVOKEVIRTUAL/GETFIELD/ARETURN + INVOKEVIRTUAL
into a GETFIELD/CHECKCAST + INVOKEVIRTUAL. The CHECKCAST is always
against a final class, hence it is just a comparison to Klass pointer
and it turns a bimorphic invocation into a monomorphic one.

Based on that analysis, this change is at least on par or a net win,
since we end up eliminating one Iterator implementation.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
