### PR TITLE
Clean up AbstractEntrySet

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -21,6 +21,7 @@ import java.util.AbstractSet;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import org.eclipse.jdt.annotation.NonNull;
 
 /**
  * Abstract base class for implementing {@link TrieMap} entry sets.
@@ -32,14 +33,10 @@ import java.util.Spliterators;
  */
 abstract sealed class AbstractEntrySet<K, V> extends AbstractSet<Entry<K, V>>
         permits ImmutableEntrySet, MutableEntrySet {
-    private final TrieMap<K, V> map;
+    final @NonNull TrieMap<K, V> map;
 
     AbstractEntrySet(final TrieMap<K, V> map) {
         this.map = requireNonNull(map);
-    }
-
-    final TrieMap<K, V> map() {
-        return map;
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -50,9 +50,8 @@ abstract sealed class AbstractEntrySet<K, V> extends AbstractSet<Entry<K, V>>
         if (key == null) {
             return false;
         }
-
-        final var value = map.get(key);
-        return value != null && value.equals(entry.getValue());
+        final var value = entry.getValue();
+        return value != null && value.equals(map.get(key));
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -31,11 +31,11 @@ import org.eclipse.jdt.annotation.NonNull;
  * @param <K> the type of entry keys
  * @param <V> the type of entry values
  */
-abstract sealed class AbstractEntrySet<K, V> extends AbstractSet<Entry<K, V>>
+abstract sealed class AbstractEntrySet<K, V, M extends TrieMap<K, V>> extends AbstractSet<Entry<K, V>>
         permits ImmutableEntrySet, MutableEntrySet {
-    final @NonNull TrieMap<K, V> map;
+    final @NonNull M map;
 
-    AbstractEntrySet(final TrieMap<K, V> map) {
+    AbstractEntrySet(final M map) {
         this.map = requireNonNull(map);
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
@@ -28,8 +28,8 @@ import java.util.Spliterator;
  * @param <K> the type of entry keys
  * @param <V> the type of entry values
  */
-final class ImmutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
-    ImmutableEntrySet(final TrieMap<K, V> map) {
+final class ImmutableEntrySet<K, V> extends AbstractEntrySet<K, V, ImmutableTrieMap<K, V>> {
+    ImmutableEntrySet(final ImmutableTrieMap<K, V> map) {
         super(map);
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableEntrySet.java
@@ -18,8 +18,6 @@ package tech.pantheon.triemap;
 import static tech.pantheon.triemap.ImmutableTrieMap.unsupported;
 
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map.Entry;
 import java.util.Spliterator;
 
 /**
@@ -41,8 +39,8 @@ final class ImmutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
     }
 
     @Override
-    public Iterator<Entry<K, V>> iterator() {
-        return map().immutableIterator();
+    public ImmutableIterator<K, V> iterator() {
+        return map.immutableIterator();
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
@@ -15,7 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Spliterator;
 
@@ -32,12 +31,12 @@ final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
 
     @Override
     public void clear() {
-        map().clear();
+        map.clear();
     }
 
     @Override
-    public Iterator<Entry<K, V>> iterator() {
-        return map().iterator();
+    public AbstractIterator<K, V> iterator() {
+        return map.iterator();
     }
 
     @Override
@@ -56,7 +55,7 @@ final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
             return false;
         }
 
-        return map().remove(key, value);
+        return map.remove(key, value);
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableEntrySet.java
@@ -24,8 +24,8 @@ import java.util.Spliterator;
  * @param <K> the type of keys
  * @param <V> the type of values
  */
-final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
-    MutableEntrySet(final TrieMap<K, V> map) {
+final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V, MutableTrieMap<K, V>> {
+    MutableEntrySet(final MutableTrieMap<K, V> map) {
         super(map);
     }
 
@@ -35,7 +35,7 @@ final class MutableEntrySet<K, V> extends AbstractEntrySet<K, V> {
     }
 
     @Override
-    public AbstractIterator<K, V> iterator() {
+    public MutableIterator<K, V> iterator() {
         return map.iterator();
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -39,7 +39,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
     @java.io.Serial
     private static final long serialVersionUID = 1L;
 
-    private transient AbstractEntrySet<K, V> entrySet;
+    private transient AbstractEntrySet<K, V, ?> entrySet;
     // Note: AbstractMap.keySet is something we do not have access to. At some point we should just not subclass
     //       AbstractMap and lower our memory footprint.
     private transient AbstractKeySet<K, ?> theKeySet;
@@ -99,7 +99,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     @Override
     public final Set<Entry<K, V>> entrySet() {
-        final AbstractEntrySet<K, V> ret;
+        final AbstractEntrySet<K, V, ?> ret;
         return (ret = entrySet) != null ? ret : (entrySet = createEntrySet());
     }
 
@@ -142,7 +142,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     /* internal methods implemented by subclasses */
 
-    abstract AbstractEntrySet<K, V> createEntrySet();
+    abstract AbstractEntrySet<K, V, ?> createEntrySet();
 
     abstract AbstractKeySet<K, ?> createKeySet();
 


### PR DESCRIPTION
- Remove AbstractEntrySet.map()
- Improve AbstractEntrySet.contains()
- Use generic TrieMap in AbstractEntrySet
