### PR TITLE
Verify Constants

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -30,6 +30,10 @@ import java.util.NoSuchElementException;
  * @param <V> the type of entry values
  */
 abstract class AbstractIterator<K, V> implements Iterator<Entry<K, V>> {
+    static {
+        Constants.verifyMaxDepth();
+    }
+
     private final BasicNode[][] nodeStack = new BasicNode[MAX_DEPTH][];
     private final int[] positionStack = new int[MAX_DEPTH];
     private final TrieMap<K, V> map;

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -23,6 +23,10 @@ import java.util.concurrent.ThreadLocalRandom;
 final class CNode<K, V> extends MainNode<K, V> {
     private static final BasicNode[] EMPTY_ARRAY = new BasicNode[0];
 
+    static {
+        Constants.verifyLevelBits();
+    }
+
     final int bitmap;
     final BasicNode[] array;
     final Gen gen;

--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -31,9 +31,9 @@ final class Constants {
     static final int HASH_BITS = Integer.SIZE;
 
     /**
-     * Size of the CNode bitmap, in bits.
+     * Size of the CNode.bitmap field, in bits.
      */
-    static final int BITMAP_BITS = Integer.SIZE;
+    private static final int BITMAP_BITS = Integer.SIZE;
 
     /**
      * Number of hash bits consumed in each CNode level.
@@ -50,13 +50,15 @@ final class Constants {
      * they would be runtime constants. We really want them to be compile-time constants. Hence we seed them manually
      * and assert the constants are correct.
      */
-    static {
+    static void verifyLevelBits() {
         final int expectedBits = (int) (Math.log(BITMAP_BITS) / Math.log(2));
         if (LEVEL_BITS != expectedBits) {
             throw new AssertionError("BITMAP_BITS=%s implies LEVEL_BITS=%s, but %s found".formatted(BITMAP_BITS,
                 expectedBits, LEVEL_BITS));
         }
+    }
 
+    static void verifyMaxDepth() {
         final int expectedDepth = (int) Math.ceil((double)HASH_BITS / LEVEL_BITS);
         if (MAX_DEPTH != expectedDepth) {
             throw new AssertionError("HASH_BITS=%s and LEVEL_BITS=%s implies MAX_DEPTH=%s, but %s found".formatted(

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -28,6 +28,8 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
     private static final VarHandle MAINNODE;
 
     static {
+        Constants.verifyLevelBits();
+
         try {
             MAINNODE = MethodHandles.lookup().findVarHandle(INode.class, "mainnode", MainNode.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {


### PR DESCRIPTION
We have a verify() method, but it never gets invoked because the
constants are always inlined (as they should be) and hence the class
never loads. Split verification of LEVEL_BITS and MAX_DEPTH and call
them when classes using them load.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
