### PR TITLE
Suppress a SpotBugs warning

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -15,6 +15,8 @@
  */
 package tech.pantheon.triemap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Various implementation-specific constants shared across classes.
  *
@@ -58,6 +60,7 @@ final class Constants {
         }
     }
 
+    @SuppressFBWarnings(value = "UM_UNNECESSARY_MATH", justification = "Verification of compile-time constants")
     static void verifyMaxDepth() {
         final int expectedDepth = (int) Math.ceil((double)HASH_BITS / LEVEL_BITS);
         if (MAX_DEPTH != expectedDepth) {


### PR DESCRIPTION
Math.ceil() is readily pre-calculated, but we want to keep the math
explicit. Suppress a SpotBugs warning.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
