### PR TITLE
Fix a Sonar warning

### DIFF
--- a/triemap/src/test/java/tech/pantheon/triemap/MutableTrieSetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableTrieSetTest.java
@@ -131,7 +131,8 @@ class MutableTrieSetTest {
 
     @Test
     void equalsNullIsFalse() {
-        assertFalse(TrieSet.create().equals(null));
+        // Scratching around our hear due to SonarCloud
+        assertNotEquals(TrieSet.create(), null);
     }
 
     @Test


### PR DESCRIPTION
Sonar does not like the explicit test, use assertNotEquals().

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
