### PR TITLE
Move Constants verification

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -32,10 +32,6 @@ import java.util.NoSuchElementException;
  */
 abstract sealed class AbstractIterator<K, V> implements Iterator<Entry<K, V>>
         permits ImmutableIterator, MutableIterator {
-    static {
-        Constants.verifyMaxDepth();
-    }
-
     private final BasicNode[][] nodeStack = new BasicNode[MAX_DEPTH][];
     private final int[] positionStack = new int[MAX_DEPTH];
     private final ImmutableTrieMap<K, V> map;

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -23,10 +23,6 @@ import java.util.concurrent.ThreadLocalRandom;
 final class CNode<K, V> extends MainNode<K, V> {
     private static final BasicNode[] EMPTY_ARRAY = new BasicNode[0];
 
-    static {
-        Constants.verifyLevelBits();
-    }
-
     final int bitmap;
     final BasicNode[] array;
     final Gen gen;

--- a/triemap/src/main/java/tech/pantheon/triemap/Constants.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Constants.java
@@ -15,57 +15,32 @@
  */
 package tech.pantheon.triemap;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 /**
- * Various implementation-specific constants shared across classes.
+ * Various implementation-specific constants shared across classes. Normally we would be deriving both
+ * {@link #LEVEL_BITS} and {@link #MAX_DEPTH} from {@link #HASH_BITS} and size of {@link CNode#bitmap}, but that would
+ * mean they would be runtime constants. We really want them to be compile-time constants. Hence we seed them manually
+ * and assert the constants are correct.
  *
  * @author Robert Varga
  */
 final class Constants {
-    private Constants() {
-        // Hidden on purpose
-    }
-
     /**
-     * Size of the hash function, in bits.
+     * Size of the hash function, in bits. This corresponds to {@link Object#hashCode()}'s size.
      */
     static final int HASH_BITS = Integer.SIZE;
 
     /**
-     * Size of the CNode.bitmap field, in bits.
-     */
-    private static final int BITMAP_BITS = Integer.SIZE;
-
-    /**
-     * Number of hash bits consumed in each CNode level.
+     * Number of hash bits consumed in each CNode level. This corresponds to <code>log<sub>2</sub>(HASH_BITS)</code>.
      */
     static final int LEVEL_BITS = 5;
 
     /**
-     * Maximum depth of a TrieMap.
+     * Maximum depth of a TrieMap. Maximum number of CNode levels. This corresponds to
+     * {@code Math.ceil(HASH_BITS / LEVEL_BITS)}.
      */
     static final int MAX_DEPTH = 7;
 
-    /*
-     * Normally we would be deriving both LEVEL_BITS and MAX_DEPTH from HASH_BITS and BITMAP_BITS, but that would mean
-     * they would be runtime constants. We really want them to be compile-time constants. Hence we seed them manually
-     * and assert the constants are correct.
-     */
-    static void verifyLevelBits() {
-        final int expectedBits = (int) (Math.log(BITMAP_BITS) / Math.log(2));
-        if (LEVEL_BITS != expectedBits) {
-            throw new AssertionError("BITMAP_BITS=%s implies LEVEL_BITS=%s, but %s found".formatted(BITMAP_BITS,
-                expectedBits, LEVEL_BITS));
-        }
-    }
-
-    @SuppressFBWarnings(value = "UM_UNNECESSARY_MATH", justification = "Verification of compile-time constants")
-    static void verifyMaxDepth() {
-        final int expectedDepth = (int) Math.ceil((double)HASH_BITS / LEVEL_BITS);
-        if (MAX_DEPTH != expectedDepth) {
-            throw new AssertionError("HASH_BITS=%s and LEVEL_BITS=%s implies MAX_DEPTH=%s, but %s found".formatted(
-                HASH_BITS, LEVEL_BITS, expectedDepth, MAX_DEPTH));
-        }
+    private Constants() {
+        // Hidden on purpose
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -28,8 +28,6 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
     private static final VarHandle MAINNODE;
 
     static {
-        Constants.verifyLevelBits();
-
         try {
             MAINNODE = MethodHandles.lookup().findVarHandle(INode.class, "mainnode", MainNode.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/triemap/src/test/java/tech/pantheon/triemap/ConstantsTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ConstantsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 PANTHEON.tech, s.r.o. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package tech.pantheon.triemap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class ConstantsTest {
+    @Test
+    void hashBits() throws Exception {
+        // We assume Object.hashCode() is 32 bits
+        assertEquals(int.class, Object.class.getDeclaredMethod("hashCode").getReturnType());
+        assertEquals(Integer.SIZE, Constants.HASH_BITS);
+    }
+
+    @Test
+    void levelBits() throws Exception {
+        // CNode.bitmap can store 32 bits
+        assertEquals(int.class, CNode.class.getDeclaredField("bitmap").getType());
+        assertEquals((int) (Math.log(Integer.SIZE) / Math.log(2)), Constants.LEVEL_BITS);
+    }
+
+    @Test
+    void maxDepth() throws Exception {
+        assertEquals((int) Math.ceil((double)Constants.HASH_BITS / Constants.LEVEL_BITS), Constants.MAX_DEPTH);
+    }
+}

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableTrieSetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableTrieSetTest.java
@@ -131,7 +131,8 @@ class MutableTrieSetTest {
 
     @Test
     void equalsNullIsFalse() {
-        assertFalse(TrieSet.create().equals(null));
+        // Scratching around our hear due to SonarCloud
+        assertNotEquals(TrieSet.create(), null);
     }
 
     @Test


### PR DESCRIPTION
We do not need to verify Constants at runtime. Add documentation and
verify constants values in a unit test -- along with type binding.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
