### PR TITLE
Fix MutableEntrySet.spliterator()'s setValue()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractEntrySet.java
@@ -62,7 +62,7 @@ abstract sealed class AbstractEntrySet<K, V, M extends TrieMap<K, V>> extends Ab
     @Override
     public final Spliterator<Entry<K, V>> spliterator() {
         // TODO: this is backed by an Iterator, we should be able to do better
-        return Spliterators.spliterator(map.immutableIterator(), Long.MAX_VALUE, characteristics());
+        return Spliterators.spliterator(map.iterator(), Long.MAX_VALUE, characteristics());
     }
 
     abstract int characteristics();

--- a/triemap/src/test/java/tech/pantheon/triemap/ImmutableEntrySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/ImmutableEntrySetTest.java
@@ -16,10 +16,12 @@
 package tech.pantheon.triemap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,5 +71,40 @@ class ImmutableEntrySetTest {
     void testRetainAll() {
         final var arg = List.of();
         assertThrows(UnsupportedOperationException.class, () -> set.retainAll(arg));
+    }
+
+    @Test
+    void testIteratorSetValue() {
+        final var map = TrieMap.create();
+        map.put("a", "b");
+        assertEquals(Map.of("a", "b"), map);
+
+        final var snap = map.immutableSnapshot();
+        assertEquals(Map.of("a", "b"), snap);
+
+        final var it = snap.createEntrySet().iterator();
+        assertTrue(it.hasNext());
+
+        final var entry = it.next();
+        assertEquals(Map.entry("a", "b"), entry);
+        assertFalse(it.hasNext());
+
+        assertThrows(UnsupportedOperationException.class, () -> entry.setValue("c"));
+        assertEquals(Map.entry("a", "b"), entry);
+        assertEquals(Map.of("a", "b"), snap);
+    }
+
+    @Test
+    void testSpliteratorSetValue() {
+        final var map = TrieMap.create();
+        map.put("a", "b");
+        assertEquals(Map.of("a", "b"), map);
+
+        final var snap = map.immutableSnapshot();
+        final var sp = snap.createEntrySet().spliterator();
+        assertTrue(sp.tryAdvance(entry -> {
+            assertThrows(UnsupportedOperationException.class, () -> entry.setValue("c"));
+        }));
+        assertEquals(Map.of("a", "b"), snap);
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/MutableEntrySetTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/MutableEntrySetTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 class MutableEntrySetTest {
     private static final String KEY = "key";
     private static final String VALUE = "value";
+    private static final String VALUE2 = "value2";
 
     private MutableEntrySet<String, String> set;
     private MutableTrieMap<String, String> map;
@@ -85,5 +86,30 @@ class MutableEntrySetTest {
         assertTrue(it.hasNext());
         assertEquals(Map.entry(KEY, VALUE), it.next());
         assertFalse(it.hasNext());
+    }
+
+    @Test
+    void testIteratorSetValue() {
+        final var it = set.iterator();
+        assertTrue(it.hasNext());
+
+        final var entry = it.next();
+        assertEquals(Map.entry(KEY, VALUE), entry);
+        assertFalse(it.hasNext());
+
+        entry.setValue(VALUE2);
+        assertEquals(Map.entry(KEY, VALUE2), entry);
+        assertEquals(Map.of(KEY, VALUE2), map);
+    }
+
+    @Test
+    void testSpliteratorSetValue() {
+        final var sp = set.spliterator();
+        assertTrue(sp.tryAdvance(entry -> {
+            assertEquals(Map.entry(KEY, VALUE), entry);
+            entry.setValue(VALUE2);
+            assertEquals(Map.entry(KEY, VALUE2), entry);
+        }));
+        assertEquals(Map.of(KEY, VALUE2), map);
     }
 }


### PR DESCRIPTION
AbstractEntrySet should not use immutableIterator(), otherwise we end up
producing Entry objects which do not support Entry.setValue(). Fix this
up and add explicit tests.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
