### PR TITLE
Do not use * imports

### DIFF
--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfAbsent.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfAbsent.java
@@ -15,10 +15,11 @@
  */
 package tech.pantheon.triemap;
 
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 class TestConcurrentMapComputeIfAbsent {
     private static final int COUNT = 50 * 1000;

--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfPresent.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfPresent.java
@@ -15,10 +15,13 @@
  */
 package tech.pantheon.triemap;
 
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
 
 class TestConcurrentMapComputeIfPresent {
     private static final int COUNT = 50 * 1000;


### PR DESCRIPTION
This is failing checkstyle, make sure we use individual static imports.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
