### PR TITLE
Fix Javadoc warnings and enforce them

### DIFF
--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -32,6 +32,10 @@
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
     <url>https://github.com/PantheonTechnologies/triemap</url>
 
+    <properties>
+        <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>biz.aQute.bnd</groupId>

--- a/triemap/src/main/java/module-info.java
+++ b/triemap/src/main/java/module-info.java
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * An implementation of {@link java.util.concurrent.ConcurrentMap} based on
+ * <a href="https://en.wikipedia.org/wiki/Ctrie">concurrent hash-trie</a>.
+ */
 module tech.pantheon.triemap {
     exports tech.pantheon.triemap;
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -48,6 +48,13 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         // Hidden on purpose
     }
 
+    /**
+     * Create a new {@link MutableTrieMap}.
+     *
+     * @param <K> key type
+     * @param <V> value type
+     * @return A new {@link MutableTrieMap}.
+     */
     public static <K, V> MutableTrieMap<K, V> create() {
         return new MutableTrieMap<>();
     }
@@ -186,6 +193,11 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         return hash;
     }
 
+    /**
+     * Replace this set with its {@link SerializationProxy}.
+     *
+     * @return {@link SerializationProxy}
+     */
     @java.io.Serial
     final Object writeReplace() {
         return new SerializationProxy(immutableSnapshot(), isReadOnly());

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieSet.java
@@ -54,6 +54,12 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
         set = map.createKeySet();
     }
 
+    /**
+     * Create a new {@link MutableTrieSet}.
+     *
+     * @param <E> element type
+     * @return A new {@link MutableTrieSet}.
+     */
     public static <E> MutableTrieSet<E> create() {
         return new MutableTrieSet<>(TrieMap.create());
     }
@@ -193,6 +199,11 @@ public abstract sealed class TrieSet<E> implements Set<E>, Serializable permits 
         return set.toString();
     }
 
+    /**
+     * Replace this set with its {@link SerializedForm}.
+     *
+     * @return {@link SerializedForm}
+     */
     @java.io.Serial
     final Object writeReplace() {
         return new SerializedForm(this);


### PR DESCRIPTION
This fixes up warnings reported by the default doclet and forces javadoc
plugin to fail if any warnings are encountered.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
