### PR TITLE
Fix Equivalence.readResolve()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Equivalence.java
@@ -36,11 +36,15 @@ abstract class Equivalence implements Serializable {
         static final Equals INSTANCE = new Equals();
 
         @Override
-        Object readResolve() {
+        Equivalence resolve() {
             return INSTANCE;
         }
     }
 
     @java.io.Serial
-    abstract Object readResolve();
+    final Object readResolve() {
+        return resolve();
+    }
+
+    abstract Equivalence resolve();
 }


### PR DESCRIPTION
We have a warning about abstract readResolve(). Fix it by making it
final and bounce through another abstract method.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
