### PR TITLE
Bump gpg-maven-plugin to 3.2.4

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -57,9 +57,8 @@
             <build>
                   <plugins>
                       <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.1.0</version>
+                          <version>3.2.4</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -59,9 +59,8 @@
             <build>
                   <plugins>
                       <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.1.0</version>
+                          <version>3.2.4</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -78,9 +78,8 @@
             <build>
                   <plugins>
                       <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
                           <artifactId>maven-gpg-plugin</artifactId>
-                          <version>3.1.0</version>
+                          <version>3.2.4</version>
                           <executions>
                               <execution>
                                   <id>sign-artifacts</id>


### PR DESCRIPTION
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.2.0
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.2.1
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.2.2
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.2.3
https://github.com/apache/maven-gpg-plugin/releases/tag/maven-gpg-plugin-3.2.4

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
