### PR TITLE
Use compareAndExchange() in obvious places

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -66,7 +66,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
 
             if (prev instanceof FailedNode) {
                 // try to commit to previous value
-                FailedNode<K, V> fn = (FailedNode<K, V>) prev;
+                final var fn = (FailedNode<K, V>) prev;
                 if (MAINNODE.compareAndSet(this, main, fn.readPrev())) {
                     return fn.readPrev();
                 }
@@ -139,7 +139,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
 
             if (m instanceof CNode) {
                 // 1) a multiway node
-                final CNode<K, V> cn = (CNode<K, V>) m;
+                final var cn = (CNode<K, V>) m;
                 final int idx = hc >>> lev & 0x1f;
                 final int flag = 1 << idx;
                 final int bmp = cn.bitmap;
@@ -226,7 +226,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
 
             if (m instanceof CNode) {
                 // 1) a multiway node
-                final CNode<K, V> cn = (CNode<K, V>) m;
+                final var cn = (CNode<K, V>) m;
                 final int idx = hc >>> lev & 0x1f;
                 final int flag = 1 << idx;
                 final int bmp = cn.bitmap;
@@ -235,7 +235,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
 
                 if ((bmp & flag) != 0) {
                     // 1a) insert below
-                    final BasicNode cnAtPos = cn.array[pos];
+                    final var cnAtPos = cn.array[pos];
                     if (cnAtPos instanceof INode) {
                         @SuppressWarnings("unchecked")
                         final var in = (INode<K, V>) cnAtPos;

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -160,7 +160,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
             return (INode<K, V>) r;
         }
         if (r instanceof RDCSS_Descriptor) {
-            return rdcssComplete(abort);
+            return rdcssComplete((RDCSS_Descriptor<K, V>) r, abort);
         }
         throw new VerifyException("Unhandled root " + r);
     }
@@ -211,16 +211,16 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         final var desc = new RDCSS_Descriptor<>(ov, expectedmain, nv);
         final var witness = casRoot(ov, desc);
         if (witness == ov) {
-            rdcssComplete(false);
-            return /* READ */desc.committed;
+            rdcssComplete(desc, false);
+            return /* READ */ desc.committed;
         }
 
         return false;
     }
 
     @SuppressWarnings("unchecked")
-    private INode<K, V> rdcssComplete(final boolean abort) {
-        var r = /* READ */ root;
+    private INode<K, V> rdcssComplete(final RDCSS_Descriptor<K, V> initial, final boolean abort) {
+        Root r = initial;
 
         while (true) {
             if (r instanceof INode) {


### PR DESCRIPTION
- **Use local variable type inference INode**
- **Use compareAndExchange() in casRoot()**
- **Improve rdcssComplete()**
- **Improve rdcssComplete() loop**
- **Use compareAndExchange() in gcasComplete()**

Fixes #178.
