### PR TITLE
Remove unneeded @SuppressFBWarnings

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
@@ -15,7 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map.Entry;
 import org.eclipse.jdt.annotation.NonNull;
 
@@ -62,7 +61,6 @@ abstract class LNodeEntry<K, V> implements Entry<K, V> {
         return EntryUtil.entryHashCode(key, value);
     }
 
-    @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public final boolean equals(final Object obj) {
         return EntryUtil.entryEquals(obj, key, value);

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableIterator.java
@@ -15,7 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map.Entry;
 
 /**
@@ -33,7 +32,7 @@ final class MutableIterator<K, V> extends AbstractIterator<K, V> {
 
     MutableIterator(final MutableTrieMap<K, V> map) {
         super(map.immutableSnapshot());
-        this.mutable = map;
+        mutable = map;
     }
 
     @Override
@@ -109,7 +108,6 @@ final class MutableIterator<K, V> extends AbstractIterator<K, V> {
             return EntryUtil.entryHashCode(getKey(), getValue());
         }
 
-        @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
         @Override
         public boolean equals(final Object obj) {
             return EntryUtil.entryEquals(obj, getKey(), getValue());

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -15,7 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.eclipse.jdt.annotation.NonNull;
 
 final class SNode<K, V> extends BasicNode implements EntryNode<K, V> {
@@ -52,7 +51,6 @@ final class SNode<K, V> extends BasicNode implements EntryNode<K, V> {
         return EntryUtil.entryHashCode(key, value);
     }
 
-    @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public boolean equals(final Object obj) {
         return EntryUtil.entryEquals(obj, key, value);

--- a/triemap/src/main/java/tech/pantheon/triemap/TNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TNode.java
@@ -15,8 +15,6 @@
  */
 package tech.pantheon.triemap;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
     final K key;
     final V value;
@@ -57,7 +55,6 @@ final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
         return EntryUtil.entryHashCode(key, value);
     }
 
-    @SuppressFBWarnings(value = "EQ_UNUSUAL",  justification = "Equality handled by utility methods")
     @Override
     public boolean equals(final Object obj) {
         return EntryUtil.entryEquals(obj, key, value);


### PR DESCRIPTION
Upgraded SpotBugs is not reporting a number of violations we have
suppressions for. Remove them to keep our code tidy.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
