### PR TITLE
Refactor INode.recRemove()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -463,15 +463,15 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
         } else if (sub instanceof SNode) {
             @SuppressWarnings("unchecked")
             final var sn = (SNode<K, V>) sub;
-            if (sn.hc == hc && key.equals(sn.key) && (cond == null || cond.equals(sn.value))) {
-                final var ncn = cn.removedAt(pos, flag, gen).toContracted(lev);
-                if (gcas(cn, ncn, ct)) {
-                    res = sn.toResult();
-                } else {
-                    return null;
-                }
-            } else {
+            if (sn.hc != hc || !key.equals(sn.key) || cond != null && !cond.equals(sn.value)) {
                 return Result.empty();
+            }
+
+            final var ncn = cn.removedAt(pos, flag, gen).toContracted(lev);
+            if (gcas(cn, ncn, ct)) {
+                res = sn.toResult();
+            } else {
+                return null;
             }
         } else {
             throw CNode.invalidElement(sub);

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -432,19 +432,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
             clean(parent, ct, lev - LEVEL_BITS);
             return null;
         } else if (m instanceof LNode) {
-            final var ln = (LNode<K, V>) m;
-            final var entry = ln.get(key);
-            if (entry == null) {
-                // Key was not found, hence no modification is needed
-                return Result.empty();
-            }
-
-            if (cond != null && !cond.equals(entry.getValue())) {
-                // Value does not match
-                return Result.empty();
-            }
-
-            return gcas(ln, ln.removeChild(entry, hc), ct) ? entry.toResult() : null;
+            return recRemove((LNode<K, V>) m, key, cond, hc, ct);
         } else {
             throw invalidElement(m);
         }
@@ -502,6 +490,22 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
         }
 
         return res;
+    }
+
+    private @Nullable Result<V> recRemove(final LNode<K, V> ln, final K key, final Object cond, final int hc,
+            final TrieMap<K, V> ct) {
+        final var entry = ln.get(key);
+        if (entry == null) {
+            // Key was not found, hence no modification is needed
+            return Result.empty();
+        }
+
+        if (cond != null && !cond.equals(entry.getValue())) {
+            // Value does not match
+            return Result.empty();
+        }
+
+        return gcas(ln, ln.removeChild(entry, hc), ct) ? entry.toResult() : null;
     }
 
     private void cleanParent(final Object nonlive, final INode<K, V> parent, final TrieMap<K, V> ct, final int hc,

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -477,11 +477,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
             throw CNode.invalidElement(sub);
         }
 
-        if (res == null || !res.isPresent()) {
-            return res;
-        }
-
-        if (parent != null) {
+        if (res != null && res.isPresent() && parent != null) {
             // never tomb at root
             final var n = gcasRead(ct);
             if (n instanceof TNode) {

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -458,7 +458,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
             } else if (gcas(cn, cn.renewed(startgen, ct), ct)) {
                 res = recRemove(key, cond, hc, lev, parent, startgen, ct);
             } else {
-                res = null;
+                return null;
             }
         } else if (sub instanceof SNode) {
             @SuppressWarnings("unchecked")
@@ -468,10 +468,10 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
                 if (gcas(cn, ncn, ct)) {
                     res = sn.toResult();
                 } else {
-                    res = null;
+                    return null;
                 }
             } else {
-                res = Result.empty();
+                return Result.empty();
             }
         } else {
             throw CNode.invalidElement(sub);


### PR DESCRIPTION
Address Sonar issues around INode.recRemove() by splitting out the CNode
and LNode cases into their separate methods.

This brings into focus a few improvements we can sprinkle, just by observing
local invariants.
