### PR TITLE
Fix version mismatch

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>bom</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>PANTHEON.tech :: TrieMap :: Bill of Materials</name>
@@ -39,12 +39,12 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>triemap</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>pt-triemap</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <type>xml</type>
                 <classifier>features</classifier>
             </dependency>
@@ -84,7 +84,7 @@
     <scm>
         <connection>scm:git:https://github.com/PantheonTechnologies/triemap.git</connection>
         <url>https://github.com/PantheonTechnologies/triemap</url>
-      <tag>triemap-1.3.1</tag>
+      <tag>triemap-1.3.3-SNAPSHOT</tag>
   </scm>
     <developers>
         <developer>

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>dependency-check</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.3-SNAPSHOT</version>
 
     <name>PANTHEON.tech :: TrieMap :: Dependency Check</name>
     <description>Artifact for validating the contents of BOM</description>
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>bom</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -74,7 +74,7 @@
         <connection>scm:git:https://github.com/PantheonTechnologies/triemap.git</connection>
         <developerConnection>scm:git:https://github.com/PantheonTechnologies/triemap.git</developerConnection>
         <url>https://github.com/PantheonTechnologies/triemap</url>
-      <tag>triemap-1.3.1</tag>
+      <tag>triemap-1.3.3-SNAPSHOT</tag>
     </scm>
     <developers>
         <developer>

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>pt-triemap</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>feature</packaging>
 
     <name>PANTHEON.tech :: TrieMap :: Feature</name>
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>tech.pantheon.triemap</groupId>
                 <artifactId>bom</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -87,7 +87,7 @@
         <connection>scm:git:https://github.com/PantheonTechnologies/triemap.git</connection>
         <developerConnection>scm:git:https://github.com/PantheonTechnologies/triemap.git</developerConnection>
         <url>https://github.com/PantheonTechnologies/triemap</url>
-      <tag>triemap-1.3.1</tag>
+      <tag>triemap-1.3.3-SNAPSHOT</tag>
   </scm>
     <developers>
         <developer>

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>tech.pantheon.triemap</groupId>
     <artifactId>triemap</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.3-SNAPSHOT</version>
 
     <name>PANTHEON.tech :: TrieMap</name>
     <description>Java implementation of a concurrent trie hash map from Scala collections library</description>
@@ -110,7 +110,7 @@
         <connection>scm:git:https://github.com/PantheonTechnologies/triemap.git</connection>
         <developerConnection>scm:git:https://github.com/PantheonTechnologies/triemap.git</developerConnection>
         <url>https://github.com/PantheonTechnologies/triemap</url>
-        <tag>triemap-1.3.1</tag>
+        <tag>triemap-1.3.3-SNAPSHOT</tag>
     </scm>
     <issueManagement>
         <system>GitHub</system>


### PR DESCRIPTION
Versions got mixed up in a previous patch, let's point to 1.3.3-SNAPSHOT
again.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
