### PR TITLE
Add coverage report pointer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.install.skip>true</maven.install.skip>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/triemap/target/site/jacoco/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <build>


### PR DESCRIPTION
Sonar needs to be able to find our report. Point to the correct
artifact.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
