### PR TITLE
Introduce Branch

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -32,7 +32,7 @@ import java.util.NoSuchElementException;
  */
 abstract sealed class AbstractIterator<K, V> implements Iterator<Entry<K, V>>
         permits ImmutableIterator, MutableIterator {
-    private final BasicNode[][] nodeStack = new BasicNode[MAX_DEPTH][];
+    private final Branch[][] nodeStack = new Branch[MAX_DEPTH][];
     private final int[] positionStack = new int[MAX_DEPTH];
     private final ImmutableTrieMap<K, V> map;
 

--- a/triemap/src/main/java/tech/pantheon/triemap/Branch.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Branch.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016 PANTHEON.tech, s.r.o. and others.
+ * (C) Copyright 2025 PANTHEON.tech, s.r.o. and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package tech.pantheon.triemap;
 
-abstract sealed class BasicNode permits MainNode, INode, SNode {
-
+/**
+ * A Branch: either an {@link INode} or an {@link SNode}.
+ */
+sealed interface Branch permits INode, SNode {
+    // Nothing else
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -24,7 +24,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import org.eclipse.jdt.annotation.Nullable;
 
-final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
+final class INode<K, V> implements Branch, MutableTrieMap.Root {
     private static final VarHandle MAINNODE;
 
     static {
@@ -195,7 +195,7 @@ final class INode<K, V> extends BasicNode implements MutableTrieMap.Root {
         }
     }
 
-    static VerifyException invalidElement(final BasicNode elem) {
+    static VerifyException invalidElement(final MainNode<?, ?> elem) {
         throw new VerifyException("An INode can host only a CNode, a TNode or an LNode, not " + elem);
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
@@ -18,7 +18,7 @@ package tech.pantheon.triemap;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-abstract sealed class MainNode<K, V> extends BasicNode permits CNode, FailedNode, LNode, TNode {
+abstract sealed class MainNode<K, V> permits CNode, FailedNode, LNode, TNode {
     static final int NO_SIZE = -1;
 
     private static final VarHandle PREV;

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -17,7 +17,7 @@ package tech.pantheon.triemap;
 
 import org.eclipse.jdt.annotation.NonNull;
 
-final class SNode<K, V> extends BasicNode implements EntryNode<K, V> {
+final class SNode<K, V> implements Branch, EntryNode<K, V> {
     final K key;
     final V value;
     final int hc;


### PR DESCRIPTION
INode and SNode have a common construct named Range. Introduce it as the
base class, disconnecting the two classes from BasicNode.

BasicNode therefore becomes an alias for MainNode, so remove BasicNode,
it clear that we are talking either about a Range or a MainNode.

This improves our type safety, as there is no common superclass of the
two sealed hierarchies.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
