### PR TITLE
Remove MainNode.casPrev()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/FailedNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/FailedNode.java
@@ -15,12 +15,14 @@
  */
 package tech.pantheon.triemap;
 
+import static java.util.Objects.requireNonNull;
+
 final class FailedNode<K, V> extends MainNode<K, V> {
     private final MainNode<K, V> prev;
 
     FailedNode(final MainNode<K, V> prev) {
         super(prev);
-        this.prev = prev;
+        this.prev = requireNonNull(prev);
     }
 
     @Override


### PR DESCRIPTION
We have two distinct cases here:
- commitPrev() making a NonNull -> null transition
- abortPrev() making a NonNull -> FailedNode transition

The former can also do better by reporting the witness value. We use it
instead of going to MainNode.readPrev() on the same node again.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
