### PR TITLE
Various warning fixes

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -503,6 +503,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                 return;
             }
 
+            @SuppressWarnings("unchecked")
             final var cn = (CNode<K, V>) cnode;
             final int idx = hc >>> lev - LEVEL_BITS & 0x1f;
             final int bmp = cn.bitmap;

--- a/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
@@ -23,11 +23,11 @@ import java.lang.invoke.VarHandle;
 abstract sealed class MainNode<K, V> permits CNode, FailedNode, LNode, TNode {
     static final int NO_SIZE = -1;
 
-    private static final VarHandle PREV;
+    private static final VarHandle VH;
 
     static {
         try {
-            PREV = MethodHandles.lookup().findVarHandle(MainNode.class, "prev", MainNode.class);
+            VH = MethodHandles.lookup().findVarHandle(MainNode.class, "prev", MainNode.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -66,10 +66,10 @@ abstract sealed class MainNode<K, V> permits CNode, FailedNode, LNode, TNode {
     }
 
     final MainNode<K, V> commitPrev(final MainNode<K, V> expected) {
-        return (MainNode<K, V>) PREV.compareAndExchange(this, requireNonNull(expected), null);
+        return (MainNode<K, V>) VH.compareAndExchange(this, requireNonNull(expected), null);
     }
 
     final void abortPrev(final MainNode<K, V> expected) {
-        PREV.compareAndSet(this, expected, new FailedNode<>(expected));
+        VH.compareAndSet(this, expected, new FailedNode<>(expected));
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -36,11 +36,11 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     @java.io.Serial
     private static final long serialVersionUID = 1L;
 
-    private static final VarHandle ROOT;
+    private static final VarHandle VH;
 
     static {
         try {
-            ROOT = MethodHandles.lookup().findVarHandle(MutableTrieMap.class, "root", Root.class);
+            VH = MethodHandles.lookup().findVarHandle(MutableTrieMap.class, "root", Root.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new ExceptionInInitializerError(e);
         }
@@ -206,7 +206,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
     }
 
     private Root casRoot(final Root ov, final Root nv) {
-        return (Root) ROOT.compareAndExchange(this, ov, nv);
+        return (Root) VH.compareAndExchange(this, ov, nv);
     }
 
     private boolean rdcssRoot(final INode<K, V> ov, final MainNode<K, V> expectedmain, final INode<K, V> nv) {


### PR DESCRIPTION
Sonar is reporting a number of warnings, this PR takes a stab at solving
the simple ones:

- **Add a warning suppression**
- **Rename MainNode.PREV**
- **Clean up INode.mainnode naming**
- **Rename MutableTrieMap.ROOT**
