### PR TITLE
Make SNode a record

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -42,13 +42,13 @@ final class CNode<K, V> extends MainNode<K, V> {
 
     static <K, V> MainNode<K,V> dual(final SNode<K, V> snode, final K key, final V value, final int hc, final int lev,
             final Gen gen) {
-        return dual(snode, snode.hc, new SNode<>(key, value, hc), hc, lev, gen);
+        return dual(snode, snode.hc(), new SNode<>(key, value, hc), hc, lev, gen);
     }
 
     private static <K, V> MainNode<K,V> dual(final SNode<K, V> first, final int firstHash, final SNode<K, V> second,
             final int secondHash, final int lev, final Gen gen) {
         if (lev >= HASH_BITS) {
-            return new LNode<>(first.key, first.value, second.key, second.value);
+            return new LNode<>(first, second);
         }
 
         final int xidx = firstHash >>> lev & 0x1f;

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -25,8 +25,8 @@ final class LNode<K, V> extends MainNode<K, V> {
         this.size = size;
     }
 
-    LNode(final K k1, final V v1, final K k2, final V v2) {
-        this(LNodeEntries.map(k1, v1, k2, v2), 2);
+    LNode(final SNode<K, V> first, final SNode<K, V> second) {
+        this(LNodeEntries.map(first.key(), first.value(), second.key(), second.value()), 2);
     }
 
     LNode<K, V> insertChild(final K key, final V value) {

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -17,29 +17,13 @@ package tech.pantheon.triemap;
 
 import org.eclipse.jdt.annotation.NonNull;
 
-final class SNode<K, V> implements Branch, DefaultEntry<K, V> {
-    final K key;
-    final V value;
-    final int hc;
-
-    SNode(final K key, final V value, final int hc) {
-        this.key = key;
-        this.value = value;
-        this.hc = hc;
-    }
-
+record SNode<K, V>(K key, V value, int hc) implements Branch, DefaultEntry<K, V> {
     TNode<K, V> copyTombed() {
         return new TNode<>(key, value, hc);
     }
 
-    @Override
-    public K key() {
-        return key;
-    }
-
-    @Override
-    public V value() {
-        return value;
+    boolean matches(final int otherHc, final Object otherKey) {
+        return hc == otherHc && otherKey.equals(key);
     }
 
     @NonNull Result<V> toResult() {


### PR DESCRIPTION
SNode is a properly-immutable DefaultEntry implementation. Make this
known to the JVM by converting it to a record.

Also introduce a matches() method, which others can call to ascertain
that a SNode matches.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
