### PR TITLE
Use a method reference to check it.next()

### DIFF
--- a/triemap/src/test/java/tech/pantheon/triemap/TestMapIterator.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestMapIterator.java
@@ -119,6 +119,6 @@ class TestMapIterator {
 
     private static void failAdvance(final Iterator<?> it) {
         assertFalse(it.hasNext());
-        assertThrows(NoSuchElementException.class, () -> it.next());
+        assertThrows(NoSuchElementException.class, it::next);
     }
 }


### PR DESCRIPTION
Use a method reference instead of a lambda.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
