### PR TITLE
Refactor INode methods, part one

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -49,6 +49,18 @@ final class CNode<K, V> extends MainNode<K, V> {
         this(gen, 0, EMPTY_ARRAY);
     }
 
+    boolean insert(final INode<K, V> in, final int pos, final SNode<K, V> sn, final K key, final V val, final int hc,
+            final int lev, final TrieMap<K, V> ct) {
+        final CNode<K, V> next;
+        if (!sn.matches(hc, key)) {
+            final var rn = gen == in.gen ? this : renewed(gen, ct);
+            next = rn.updatedAt(pos, new INode<>(in, sn, key, val, hc, lev), gen);
+        } else {
+            next = updatedAt(pos, key, val, hc, gen);
+        }
+        return in.gcasWrite(next, ct);
+    }
+
     static <K, V> MainNode<K, V> dual(final SNode<K, V> first, final K key, final V value, final int hc,
             final int initLev, final Gen gen) {
         final var second = new SNode<>(key, value, hc);

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -421,9 +421,8 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
         while (true) {
             final var m = gcasRead(ct);
 
-            if (m instanceof CNode) {
+            if (m instanceof CNode<K, V> cn) {
                 // 1) a multinode
-                final var cn = (CNode<K, V>) m;
                 final int idx = hc >>> lev & 0x1f;
                 final int flag = 1 << idx;
                 final int bmp = cn.bitmap;
@@ -457,13 +456,12 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                 } else {
                     throw CNode.invalidElement(sub);
                 }
-            } else if (m instanceof TNode) {
+            } else if (m instanceof TNode<K, V> tn) {
                 // 3) non-live node
-                return cleanReadOnly((TNode<K, V>) m, lev, parent, ct, key, hc);
-            } else if (m instanceof LNode) {
+                return cleanReadOnly(tn, lev, parent, ct, key, hc);
+            } else if (m instanceof LNode<K, V> ln) {
                 // 5) an l-node
-                final var entry = ((LNode<K, V>) m).get(key);
-                return entry != null ? entry.value() : null;
+                return ln.lookup(key);
             } else {
                 throw invalidElement(m);
             }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -307,9 +307,8 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
         while (true) {
             final var m = gcasRead(ct);
 
-            if (m instanceof CNode) {
+            if (m instanceof CNode<K, V> cn) {
                 // 1) a multiway node
-                final var cn = (CNode<K, V>) m;
                 final int idx = hc >>> lev & 0x1f;
                 final int flag = 1 << idx;
                 final int bmp = cn.bitmap;
@@ -348,9 +347,9 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
             } else if (m instanceof TNode) {
                 clean(parent, ct, lev - LEVEL_BITS);
                 return null;
-            } else if (m instanceof LNode<?, ?> ln) {
+            } else if (m instanceof LNode<K, V> ln) {
                 // 3) an l-node
-                return insertIf(ln, key, val, cond, ct);
+                return ln.insertIf(this, key, val, cond, ct);
             } else {
                 throw invalidElement(m);
             }
@@ -370,33 +369,6 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
             return gcasWrite(cn.updatedAt(pos, key, val, hc, gen), ct) ? sn.toResult() : null;
         }
         return Result.empty();
-    }
-
-    private @Nullable Result<V> insertIf(final LNode<?, ?> lnode, final K key, final V val, final Object cond,
-            final TrieMap<K, V> ct) {
-        @SuppressWarnings("unchecked")
-        final var ln = (LNode<K, V>) lnode;
-        final var entry = ln.get(key);
-
-        if (entry == null) {
-            return cond != null && cond != ABSENT || insertln(ln, key, val, ct) ? Result.empty() : null;
-        }
-        if (cond == ABSENT) {
-            return entry.toResult();
-        } else if (cond == null || cond == PRESENT || cond.equals(entry.value())) {
-            return replaceln(ln, entry, val, ct) ? entry.toResult() : null;
-        }
-        return Result.empty();
-    }
-
-    // FIXME: should live in LNode
-    private boolean insertln(final LNode<K, V> ln, final K key, final V val, final TrieMap<K, V> ct) {
-        return gcasWrite(ln.insertChild(key, val), ct);
-    }
-
-    // FIXME: should live in LNode
-    private boolean replaceln(final LNode<K, V> ln, final LNodeEntry<K, V> entry, final V val, final TrieMap<K, V> ct) {
-        return gcasWrite(ln.replaceChild(entry, val), ct);
     }
 
     /**

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -460,13 +460,13 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
             final INode<K, V> parent, final Gen startgen, final TrieMap<K, V> ct) {
         final var m = gcasRead(ct);
 
-        if (m instanceof CNode) {
-            return recRemove((CNode<K, V>) m, key, cond, hc, lev, parent, startgen, ct);
+        if (m instanceof CNode<K, V> cn) {
+            return recRemove(cn, key, cond, hc, lev, parent, startgen, ct);
         } else if (m instanceof TNode) {
             clean(parent, ct, lev - LEVEL_BITS);
             return null;
-        } else if (m instanceof LNode) {
-            return recRemove((LNode<K, V>) m, key, cond, hc, ct);
+        } else if (m instanceof LNode<K, V> ln) {
+            return ln.remove(this, key, cond, hc, ct);
         } else {
             throw invalidElement(m);
         }
@@ -516,22 +516,6 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
         }
 
         return res;
-    }
-
-    private @Nullable Result<V> recRemove(final LNode<K, V> ln, final K key, final Object cond, final int hc,
-            final TrieMap<K, V> ct) {
-        final var entry = ln.get(key);
-        if (entry == null) {
-            // Key was not found, hence no modification is needed
-            return Result.empty();
-        }
-
-        if (cond != null && !cond.equals(entry.value())) {
-            // Value does not match
-            return Result.empty();
-        }
-
-        return gcasWrite(ln.removeChild(entry, hc), ct) ? entry.toResult() : null;
     }
 
     private void cleanParent(final TNode<?, ?> tn, final INode<K, V> parent, final TrieMap<K, V> ct, final int hc,

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -450,9 +450,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                     return RESTART;
                 } else if (sub instanceof SNode) {
                     // 2) singleton node
-                    @SuppressWarnings("unchecked")
-                    final var sn = (SNode<K, V>) sub;
-                    return sn.matches(hc, key) ? sn.value() : null;
+                    return ((SNode<K, V>) sub).lookup(hc, key);
                 } else {
                     throw CNode.invalidElement(sub);
                 }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -38,6 +38,11 @@ final class LNode<K, V> extends MainNode<K, V> {
         return entry != null ? entry.value() : null;
     }
 
+    boolean insert(final INode<K, V> in, final K key, final V val, final TrieMap<K, V> ct) {
+        final var entry = get(key);
+        return in.gcasWrite(entry != null ? replaceChild(entry, val) : insertChild(key, val), ct);
+    }
+
     LNode<K, V> insertChild(final K key, final V value) {
         return new LNode<>(this, entries.insert(key, value), size + 1);
     }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -15,6 +15,8 @@
  */
 package tech.pantheon.triemap;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 final class LNode<K, V> extends MainNode<K, V> {
     // Internally-linked single list of of entries
     private final LNodeEntries<K, V> entries;
@@ -29,6 +31,11 @@ final class LNode<K, V> extends MainNode<K, V> {
     LNode(final SNode<K, V> first, final SNode<K, V> second) {
         entries = LNodeEntries.map(first.key(), first.value(), second.key(), second.value());
         size = 2;
+    }
+
+    @Nullable V lookup(final K key) {
+        final var entry = entries.findEntry(key);
+        return entry != null ? entry.value() : null;
     }
 
     LNode<K, V> insertChild(final K key, final V value) {

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -23,8 +23,8 @@ record SNode<K, V>(K key, V value, int hc) implements Branch, EntryNode<K, V> {
         return new TNode<>(prev, key, value, hc);
     }
 
-    @Nullable V lookup(final int hc, final K key) {
-        return matches(hc, key) ? value : null;
+    @Nullable V lookup(final int otherHc, final K otherKey) {
+        return matches(otherHc, otherKey) ? value : null;
     }
 
     boolean matches(final int otherHc, final Object otherKey) {

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -16,10 +16,15 @@
 package tech.pantheon.triemap;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 record SNode<K, V>(K key, V value, int hc) implements Branch, EntryNode<K, V> {
     TNode<K, V> copyTombed(final CNode<K, V> prev) {
         return new TNode<>(prev, key, value, hc);
+    }
+
+    @Nullable V lookup(final int hc, final K key) {
+        return matches(hc, key) ? value : null;
     }
 
     boolean matches(final int otherHc, final Object otherKey) {


### PR DESCRIPTION
INode has a ton of methods to deal with the other possible nodes, including
how to execute operations on them.

Rather than having such a centralized place, move some methods to
CNode/LNode/SNode where they can be maintained and improved.

- **Add LNodeEntry.lookup()**
- **Add SNode.lookup()**
- **Add CNode.insert()**
- **Add LNode.insert()**
- **Add LNode.insertIf()**
- **Add LNode.remove()**
