### PR TITLE
Move more INode mutators

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -88,17 +88,16 @@ abstract sealed class AbstractIterator<K, V> implements Iterator<Entry<K, V>>
      */
     private void readin(final INode<K, V> in) {
         final var m = in.gcasRead(map);
-        if (m instanceof CNode) {
+        if (m instanceof CNode<K, V> cn) {
             // Enter the next level
-            final var cn = (CNode<K, V>) m;
             depth++;
             nodeStack[depth] = cn.array;
             positionStack[depth] = -1;
             advance();
-        } else if (m instanceof TNode) {
-            current = (TNode<K, V>) m;
-        } else if (m instanceof LNode) {
-            lnode = ((LNode<K, V>) m).entries();
+        } else if (m instanceof TNode<K, V> tn) {
+            current = tn;
+        } else if (m instanceof LNode<K, V> ln) {
+            lnode = ln.entries;
         } else if (m == null) {
             current = null;
         }

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -84,6 +84,16 @@ final class CNode<K, V> extends MainNode<K, V> {
         return Result.empty();
     }
 
+    @Nullable Result<V> remove(final INode<K, V> in, final int flag, final int pos, final SNode<?, ?> snode,
+            final K key, final int hc, final Object cond, final int lev, final TrieMap<K, V> ct) {
+        @SuppressWarnings("unchecked")
+        final var sn = (SNode<K, V>) snode;
+        if (!sn.matches(hc, key) || cond != null && !cond.equals(sn.value())) {
+            return Result.empty();
+        }
+        return in.gcasWrite(removedAt(pos, flag, gen).toContracted(this, lev), ct) ? sn.toResult() : null;
+    }
+
     static <K, V> MainNode<K, V> dual(final SNode<K, V> first, final K key, final V value, final int hc,
             final int initLev, final Gen gen) {
         final var second = new SNode<>(key, value, hc);

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -269,7 +269,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                 clean(parent, ct, lev - LEVEL_BITS);
                 return false;
             } else if (m instanceof LNode<K, V> ln) {
-                return ln.insert(this, key, val, ct);
+                return ln.entries.insert(this, ln, key, val, ct);
             } else {
                 throw invalidElement(m);
             }
@@ -349,7 +349,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                 return null;
             } else if (m instanceof LNode<K, V> ln) {
                 // 3) an l-node
-                return ln.insertIf(this, key, val, cond, ct);
+                return ln.entries.insertIf(this, ln, key, val, cond, ct);
             } else {
                 throw invalidElement(m);
             }
@@ -424,7 +424,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
                 return cleanReadOnly(tn, lev, parent, ct, key, hc);
             } else if (m instanceof LNode<K, V> ln) {
                 // 5) an l-node
-                return ln.lookup(key);
+                return ln.entries.lookup(key);
             } else {
                 throw invalidElement(m);
             }
@@ -466,7 +466,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
             clean(parent, ct, lev - LEVEL_BITS);
             return null;
         } else if (m instanceof LNode<K, V> ln) {
-            return ln.remove(this, key, cond, hc, ct);
+            return ln.entries.remove(this, ln, key, cond, hc, ct);
         } else {
             throw invalidElement(m);
         }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -472,18 +472,8 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
             } else {
                 return null;
             }
-        } else if (sub instanceof SNode) {
-            @SuppressWarnings("unchecked")
-            final var sn = (SNode<K, V>) sub;
-            if (sn.matches(hc, key) && (cond == null || cond.equals(sn.value()))) {
-                if (gcasWrite(cn.removedAt(pos, flag, gen).toContracted(cn, lev), ct)) {
-                    res = sn.toResult();
-                } else {
-                    return null;
-                }
-            } else {
-                return Result.empty();
-            }
+        } else if (sub instanceof SNode<?, ?> sn) {
+            res = cn.remove(this, flag, pos, sn, key, hc, cond, lev, ct);
         } else {
             throw CNode.invalidElement(sub);
         }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -15,32 +15,19 @@
  */
 package tech.pantheon.triemap;
 
-import static tech.pantheon.triemap.PresencePredicate.ABSENT;
-import static tech.pantheon.triemap.PresencePredicate.PRESENT;
-
-import org.eclipse.jdt.annotation.Nullable;
-
 final class LNode<K, V> extends MainNode<K, V> {
     // Internally-linked single list of of entries
-    private final LNodeEntries<K, V> entries;
-    private final int size;
+    final LNodeEntries<K, V> entries;
+    final int size;
 
-    private LNode(final LNode<K, V> prev, final LNodeEntries<K, V> entries, final int size) {
+    LNode(final LNode<K, V> prev, final LNodeEntries<K, V> entries, final int size) {
         super(prev);
         this.entries = entries;
         this.size = size;
     }
 
-    private LNode(final LNode<K, V> prev, final K key, final V value) {
-        this(prev, prev.entries.insert(key, value), prev.size + 1);
-    }
-
-    private LNode(final LNode<K, V> prev, final LNodeEntry<K, V> entry, final V value) {
-        this(prev, prev.entries.replace(entry, value), prev.size);
-    }
-
     LNode(final SNode<K, V> first, final SNode<K, V> second) {
-        entries = LNodeEntries.map(first.key(), first.value(), second.key(), second.value());
+        entries = LNodeEntries.of(first.key(), first.value(), second.key(), second.value());
         size = 2;
     }
 
@@ -52,57 +39,5 @@ final class LNode<K, V> extends MainNode<K, V> {
     @Override
     int size(final ImmutableTrieMap<?, ?> ct) {
         return size;
-    }
-
-    LNodeEntries<K, V> entries() {
-        return entries;
-    }
-
-    @Nullable V lookup(final K key) {
-        final var entry = entries.findEntry(key);
-        return entry != null ? entry.value() : null;
-    }
-
-    boolean insert(final INode<K, V> in, final K key, final V val, final TrieMap<K, V> ct) {
-        final var entry = entries.findEntry(key);
-        return in.gcasWrite(entry != null ? new LNode<>(this, entry, val) : new LNode<>(this, key, val), ct);
-    }
-
-    @Nullable Result<V> insertIf(final INode<K, V> in, final K key, final V val, final Object cond,
-            final TrieMap<K, V> ct) {
-        final var entry = entries.findEntry(key);
-        if (entry == null) {
-            return cond != null && cond != ABSENT || in.gcasWrite(new LNode<>(this, key, val), ct)
-                ? Result.empty() : null;
-        }
-        if (cond == ABSENT) {
-            return entry.toResult();
-        } else if (cond == null || cond == PRESENT || cond.equals(entry.value())) {
-            return in.gcasWrite(new LNode<>(this, entry, val), ct) ? entry.toResult() : null;
-        }
-        return Result.empty();
-    }
-
-    @Nullable Result<V> remove(final INode<K, V> in, final K key, final Object cond, final int hc,
-            final TrieMap<K, V> ct) {
-        final var entry = entries.findEntry(key);
-        if (entry == null) {
-            // Key was not found, hence no modification is needed
-            return Result.empty();
-        }
-        if (cond != null && !cond.equals(entry.value())) {
-            // Value does not match
-            return Result.empty();
-        }
-        // While remove() can return null, that case will never happen here, as we are starting off with two entries
-        // so we cannot observe a null return here.
-        final var map = VerifyException.throwIfNull(entries.remove(entry));
-        // If the returned LNode would have only one element, we turn it intoa TNode, so it can be turned into SNode on
-        // next lookup
-        final var next = size == 2
-            ? new TNode<>(this, map.key(), map.value(), hc)
-            : new LNode<>(this, map, size - 1);
-
-        return in.gcasWrite(next, ct) ? entry.toResult() : null;
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/LNodeEntriesTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/LNodeEntriesTest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class LNodeEntriesTest {
-    private LNodeEntries<Integer, Boolean> map = LNodeEntries.map(1, TRUE, 2, TRUE);
+    private LNodeEntries<Integer, Boolean> map = LNodeEntries.of(1, TRUE, 2, TRUE);
 
     @Test
     void testReplaceInvalid() {
@@ -41,7 +41,7 @@ class LNodeEntriesTest {
         assertEquals(map.next(), modified.next());
         assertEquals(Map.entry(1, FALSE), modified);
 
-        final var trimmed = modified.remove(modified);
+        final var trimmed = modified.removeEntry(modified);
         assertEquals(Map.entry(2, TRUE), trimmed.replace(trimmed, TRUE));
     }
 
@@ -51,22 +51,22 @@ class LNodeEntriesTest {
         assertEquals(map, modified.next());
         assertEquals(Map.entry(2, FALSE), modified);
 
-        final var trimmed = modified.remove(modified);
+        final var trimmed = modified.removeEntry(modified);
         assertEquals(Map.entry(1, TRUE), trimmed.replace(trimmed, TRUE));
     }
 
     @Test
     void testRemoveHead() {
-        final var modified = map.remove(map);
+        final var modified = map.removeEntry(map);
         assertSame(map.next(), modified);
-        assertNull(modified.remove(modified));
+        assertNull(modified.removeEntry(modified));
     }
 
     @Test
     void testRemoveTail() {
-        final LNodeEntries<Integer, Boolean> modified = map.remove(map.next());
+        final LNodeEntries<Integer, Boolean> modified = map.removeEntry(map.next());
         assertEquals(map, modified);
-        assertNull(modified.remove(modified));
+        assertNull(modified.removeEntry(modified));
     }
 
     /**
@@ -76,7 +76,7 @@ class LNodeEntriesTest {
     void testGetOverflow() {
         // 30K seems to be enough to trigger the problem locally
         for (int i = 3; i < 30000; ++i) {
-            map = map.insert(i, TRUE);
+            map = map.insertEntry(i, TRUE);
         }
 
         assertNull(map.findEntry(0));

--- a/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/LNodeEntryTest.java
@@ -26,7 +26,7 @@ class LNodeEntryTest {
     private static final String KEY2 = "key2";
     private static final String VALUE = "value";
 
-    private final LNodeEntries<String, String> entry = LNodeEntries.map(KEY1, VALUE, KEY2, VALUE);
+    private final LNodeEntries<String, String> entry = LNodeEntries.of(KEY1, VALUE, KEY2, VALUE);
 
     @Test
     void testEntryUtil() {


### PR DESCRIPTION
INode is acting as a hug for all manner of operations, this
rehosts the rest of LNode and CNode operations.

- **Forward LNode operations to LNodeEntries**
- **Add CNode.insertIf()**
- **Add CNode.remove()**
