### PR TITLE
Refactor INode.recInsertIf()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -63,8 +63,8 @@ final class CNode<K, V> extends MainNode<K, V> {
         return in.gcasWrite(next, ct);
     }
 
-    @Nullable Result<V> insertIf(final INode<K, V> in, final int pos, final SNode<?, ?> snode, final K key,
-            final V val, final int hc, final Object cond, final int lev, final TrieMap<K, V> ct) {
+    @Nullable Result<V> insertIf(final MutableTrieMap<K, V> ct, final INode<K, V> in, final int pos,
+            final SNode<?, ?> snode, final K key, final V val, final int hc, final Object cond, final int lev) {
         @SuppressWarnings("unchecked")
         final var sn = (SNode<K, V>) snode;
         if (!sn.matches(hc, key)) {

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
@@ -88,8 +88,8 @@ abstract sealed class LNodeEntries<K, V> extends LNodeEntry<K, V> {
         return in.gcasWrite(entry == null ? toInserted(ln, key, val) : toReplaced(ln, entry, val), ct);
     }
 
-    @Nullable Result<V> insertIf(final INode<K, V> in, final LNode<K, V> ln, final K key, final V val,
-            final Object cond, final TrieMap<K, V> ct) {
+    @Nullable Result<V> insertIf(final MutableTrieMap<K, V> ct, final INode<K, V> in, final LNode<K, V> ln, final K key,
+            final V val, final Object cond) {
         final var entry = findEntry(key);
         if (entry == null) {
             return cond != null && cond != ABSENT || in.gcasWrite(toInserted(ln, key, val), ct) ? Result.empty() : null;


### PR DESCRIPTION
Just as we have done with INode.recRemove(), rehost recInsertIf() into
MutableTrieMap, refactored to use a loop instead of recursion.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
