### PR TITLE
Make Branch/Root generic

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/AbstractIterator.java
@@ -32,7 +32,8 @@ import java.util.NoSuchElementException;
  */
 abstract sealed class AbstractIterator<K, V> implements Iterator<Entry<K, V>>
         permits ImmutableIterator, MutableIterator {
-    private final Branch[][] nodeStack = new Branch[MAX_DEPTH][];
+    @SuppressWarnings("unchecked")
+    private final Branch<K, V>[][] nodeStack = new Branch[MAX_DEPTH][];
     private final int[] positionStack = new int[MAX_DEPTH];
     private final ImmutableTrieMap<K, V> map;
 
@@ -103,7 +104,6 @@ abstract sealed class AbstractIterator<K, V> implements Iterator<Entry<K, V>>
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void advance() {
         if (depth >= 0) {
             int npos = positionStack[depth] + 1;

--- a/triemap/src/main/java/tech/pantheon/triemap/Branch.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Branch.java
@@ -18,6 +18,6 @@ package tech.pantheon.triemap;
 /**
  * A Branch: either an {@link INode} or an {@link SNode}.
  */
-sealed interface Branch permits INode, SNode {
+sealed interface Branch<K, V> permits INode, SNode {
     // Nothing else
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -24,7 +24,7 @@ import java.lang.invoke.VarHandle;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
-final class INode<K, V> implements Branch, MutableTrieMap.Root {
+final class INode<K, V> implements Branch<K, V>, MutableTrieMap.Root<K, V> {
     /**
      * A GCAS-protected {@link MainNode}. This can be effectively either a {@link FailedGcas} or a {@link MainNode}.
      */
@@ -210,7 +210,7 @@ final class INode<K, V> implements Branch, MutableTrieMap.Root {
         }
     }
 
-    INode<K, V> copyToGen(final Gen ngen, final TrieMap<?, ?> ct) {
+    INode<K, V> copyToGen(final Gen ngen, final TrieMap<K, V> ct) {
         return new INode<>(ngen, gcasRead(ct));
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -18,7 +18,7 @@ package tech.pantheon.triemap;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
-record SNode<K, V>(K key, V value, int hc) implements Branch, EntryNode<K, V> {
+record SNode<K, V>(K key, V value, int hc) implements Branch<K, V>, EntryNode<K, V> {
     TNode<K, V> copyTombed(final CNode<K, V> prev) {
         return new TNode<>(prev, key, value, hc);
     }

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -252,9 +252,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
                 // 1b) bitmap contains a value - descend
                 final int pos = bmp == 0xffffffff ? idx : Integer.bitCount(bmp & flag - 1);
                 final var sub = cn.array[pos];
-                if (sub instanceof INode<?, ?> inode) {
-                    @SuppressWarnings("unchecked")
-                    final var in = (INode<K, V>) inode;
+                if (sub instanceof INode<K, V> in) {
                     // try to renew if needed
                     if (!isReadOnly() && startGen != in.gen && !current.gcasWrite(cn.renewed(startGen, this), this)) {
                         return RESTART;
@@ -264,9 +262,9 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
                     parent = current;
                     current = in;
                     lev += LEVEL_BITS;
-                } else if (sub instanceof SNode<?, ?> snode) {
+                } else if (sub instanceof SNode<K, V> sn) {
                     // 2) singleton node
-                    return ((SNode<K, V>) snode).lookup(hc, key);
+                    return sn.lookup(hc, key);
                 } else {
                     throw invalidElement(sub);
                 }
@@ -294,7 +292,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         }
     }
 
-    static final VerifyException invalidElement(final Branch elem) {
+    static final VerifyException invalidElement(final Branch<?, ?> elem) {
         throw new VerifyException("A CNode can contain only INodes and SNodes, not " + elem);
     }
 


### PR DESCRIPTION
This allows us to rehost some warning suppressions to a place where they
do not interfere, as we can now use instanceof with generic types.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
