### PR TITLE
Repurpose Result

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -179,10 +179,8 @@ final class CNode<K, V> extends MainNode<K, V> {
         final var cnAtPos = array[pos];
         if (cnAtPos instanceof INode<K, V> in) {
             // enter next level
-            if (startGen != in.gen && !renew(ct, parent, startGen)) {
-                return RESTART;
-            }
-            return in.insertIf(ct, startGen, hc, key, val, cond, lev + LEVEL_BITS, parent);
+            return startGen != in.gen && !renew(ct, parent, startGen)
+                ? RESTART : in.insertIf(ct, startGen, hc, key, val, cond, lev + LEVEL_BITS, parent);
         } else if (cnAtPos instanceof SNode<K, V> sn) {
             return insertIf(ct, parent, pos, sn, key, val, hc, cond, lev);
         } else {

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntry.java
@@ -44,8 +44,4 @@ abstract sealed class LNodeEntry<K, V> extends AbstractEntry<K, V> permits LNode
     public final V value() {
         return value;
     }
-
-    final @NonNull Result<V> toResult() {
-        return new Result<>(value);
-    }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/Result.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Result.java
@@ -15,24 +15,10 @@
  */
 package tech.pantheon.triemap;
 
-import org.eclipse.jdt.annotation.NonNull;
-
 /**
- * Insertion result, similar to {@link java.util.Optional}, except heavily customized for our use.
++ * Virtual result for lookup/insert methods indicating that the lookup needs to be restarted. This is a faster version
++ * of throwing a checked exception to control restart.
  */
-record Result<T>(T value) {
-    private static final @NonNull Result<?> EMPTY = new Result<>(null);
-
-    @SuppressWarnings("unchecked")
-    static <T> @NonNull Result<T> empty() {
-        return (Result<T>) EMPTY;
-    }
-
-    boolean isPresent() {
-        return value != null;
-    }
-
-    T orNull() {
-        return value;
-    }
+enum Result {
+    RESTART;
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -31,10 +31,6 @@ record SNode<K, V>(@NonNull K key, @NonNull V value, int hc) implements Branch<K
         return hc == otherHc && otherKey.equals(key);
     }
 
-    @NonNull Result<V> toResult() {
-        return new Result<>(value);
-    }
-
     @Override
     public int elementSize(final ImmutableTrieMap<K, V> ct) {
         return 1;

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -16,6 +16,7 @@
 package tech.pantheon.triemap;
 
 import static java.util.Objects.requireNonNull;
+import static tech.pantheon.triemap.Result.RESTART;
 
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -37,10 +38,6 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         permits ImmutableTrieMap, MutableTrieMap {
     @java.io.Serial
     private static final long serialVersionUID = 1L;
-
-    // Virtual result for lookup methods indicating that the lookup needs to be restarted. This is a faster version
-    // of throwing a checked exception to control restart.
-    static final Object RESTART = new Object();
 
     private transient AbstractEntrySet<K, V, ?> entrySet;
     // Note: AbstractMap.keySet is something we do not have access to. At some point we should just not subclass


### PR DESCRIPTION
Redesign this class to do what LookupResult used to do -- be just a
singleton indicator of restart. This allows us to ditch object
allocation from insert return paths.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
