### PR TITLE
Use simple traversal

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/Branch.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/Branch.java
@@ -19,5 +19,11 @@ package tech.pantheon.triemap;
  * A Branch: either an {@link INode} or an {@link SNode}.
  */
 sealed interface Branch<K, V> permits INode, SNode {
-    // Nothing else
+    /**
+     * Return the number of entries for the purposes of {@link CNode#size(ImmutableTrieMap)}.
+     *
+     * @param ct TrieMap reference
+     * @return The actual number of entries
+     */
+    int elementSize(ImmutableTrieMap<K, V> ct);
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -54,6 +54,10 @@ final class CNode<K, V> extends MainNode<K, V> {
         this(gen, 0, (Branch<K, V>[]) EMPTY_ARRAY);
     }
 
+    boolean renew(final TrieMap<K, V> ct, final INode<K, V> in, final Gen ngen) {
+        return in.gcasWrite(renewed(ngen, ct), ct);
+    }
+
     boolean insert(final MutableTrieMap<K, V> ct, final INode<K, V> in, final int pos, final SNode<K, V> sn,
             final K key, final V val, final int hc, final int lev) {
         final CNode<K, V> next;

--- a/triemap/src/main/java/tech/pantheon/triemap/CNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/CNode.java
@@ -70,6 +70,13 @@ final class CNode<K, V> extends MainNode<K, V> {
         return in.gcasWrite(next, ct);
     }
 
+    boolean insert(final MutableTrieMap<K, V> ct, final INode<K, V> in, final int pos, final int flag, final K key,
+            final V val, final int hc) {
+        final var ngen = in.gen;
+        final var rn = gen == ngen ? this : renewed(ngen, ct);
+        return in.gcasWrite(rn.toInsertedAt(this, ngen, pos, flag, key, val, hc), ct);
+    }
+
     @Nullable Result<V> insertIf(final MutableTrieMap<K, V> ct, final INode<K, V> in, final int pos,
             final SNode<K, V> sn, final K key, final V val, final int hc, final Object cond, final int lev) {
         if (!sn.matches(hc, key)) {
@@ -198,7 +205,7 @@ final class CNode<K, V> extends MainNode<K, V> {
         return updatedAt(pos, new SNode<>(key, val, hc), ngen);
     }
 
-    CNode<K, V> toInsertedAt(final CNode<K, V> prev, final Gen ngen, final int pos, final int flag, final K key,
+    private CNode<K, V> toInsertedAt(final CNode<K, V> prev, final Gen ngen, final int pos, final int flag, final K key,
             final V value, final int hc) {
         final int len = array.length;
         final var narr = newArray(len + 1);
@@ -220,7 +227,7 @@ final class CNode<K, V> extends MainNode<K, V> {
      * Returns a copy of this cnode such that all the i-nodes below it are copied to the specified generation
      * {@code ngen}.
      */
-    CNode<K, V> renewed(final Gen ngen, final TrieMap<K, V> ct) {
+    private CNode<K, V> renewed(final Gen ngen, final TrieMap<K, V> ct) {
         final var arr = array;
         final int len = arr.length;
         final var narr = newArray(len);

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -215,7 +215,8 @@ final class INode<K, V> implements Branch<K, V>, MutableTrieMap.Root<K, V> {
         return new INode<>(ngen, gcasRead(ct));
     }
 
-    int readSize(final ImmutableTrieMap<?, ?> ct) {
+    @Override
+    public int elementSize(final ImmutableTrieMap<K, V> ct) {
         return gcasReadNonNull(ct).size(ct);
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/INode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/INode.java
@@ -210,73 +210,35 @@ final class INode<K, V> implements Branch<K, V>, MutableTrieMap.Root<K, V> {
         }
     }
 
-    Object lookup(final TrieMap<K, V> ct, final int hc, final K key) {
-        return recLookup(ct, this, hc, key);
-    }
-
     /**
      * Looks up the value associated with the key.
      *
-     * @param first root {@link INode}
+     * @param ct the ctrie
      * @param hc the hash code
      * @param key the key
      * @return null if no value has been found, RESTART if the operation was not successful, or any other value
      *         otherwise
      */
-    private static <K, V> Object recLookup(final TrieMap<K, V> ct, final INode<K, V> first, final int hc, final K key) {
-        final var startGen = first.gen;
-        INode<K, V> parent = null;
-        var current = first;
-        int lev = 0;
+    Object lookup(final TrieMap<K, V> ct, final Gen startGen, final int hc, final K key, final int lev,
+            final INode<K, V> parent) {
+        final var m = gcasRead(ct);
 
-        while (true) {
-            final var m = current.gcasRead(ct);
-
-            if (m instanceof CNode<K, V> cn) {
-                // 1) a multinode
-                final int idx = hc >>> lev & 0x1f;
-                final int flag = 1 << idx;
-
-                final int bmp = cn.bitmap;
-                if ((bmp & flag) == 0) {
-                    // 1a) bitmap shows no binding
-                    return null;
-                }
-
-                // 1b) bitmap contains a value - descend
-                final int pos = bmp == 0xffffffff ? idx : Integer.bitCount(bmp & flag - 1);
-                final var sub = cn.array[pos];
-                if (sub instanceof INode<K, V> in) {
-                    // try to renew if needed
-                    if (!ct.isReadOnly() && startGen != in.gen && !cn.renew(ct, current, startGen)) {
-                        return TrieMap.RESTART;
-                    }
-
-                    // enter next level
-                    parent = current;
-                    current = in;
-                    lev += LEVEL_BITS;
-                } else if (sub instanceof SNode<K, V> sn) {
-                    // 2) singleton node
-                    return sn.lookup(hc, key);
-                } else {
-                    throw TrieMap.invalidElement(sub);
-                }
-            } else if (m instanceof TNode<K, V> tn) {
-                // 3) non-live node
-                if (ct.isReadOnly()) {
-                    // read-only side does not clean up
-                    return tn.hc == hc && key.equals(tn.key) ? tn.value : null;
-                }
-                // read-write: perform some clean up and restart
-                ct.clean(current, parent, lev - LEVEL_BITS);
-                return TrieMap.RESTART;
-            } else if (m instanceof LNode<K, V> ln) {
-                // 5) an l-node
-                return ln.entries.lookup(key);
-            } else {
-                throw TrieMap.invalidElement(m);
+        if (m instanceof CNode<K, V> cn) {
+            return cn.lookup(ct, startGen, hc, key, lev, this);
+        } else if (m instanceof TNode<K, V> tn) {
+            // 3) non-live node
+            if (ct.isReadOnly()) {
+                // read-only side does not clean up
+                return tn.hc == hc && key.equals(tn.key) ? tn.value : null;
             }
+            // read-write: perform some clean up and restart
+            ct.clean(this, parent, lev - LEVEL_BITS);
+            return TrieMap.RESTART;
+        } else if (m instanceof LNode<K, V> ln) {
+            // 5) an l-node
+            return ln.entries.lookup(key);
+        } else {
+            throw TrieMap.invalidElement(m);
         }
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -104,12 +104,12 @@ public final class ImmutableTrieMap<K, V> extends TrieMap<K, V> {
 
     @Override
     public int size() {
-        return root.size(this);
+        return root.readSize(this);
     }
 
     @Override
     public MutableTrieMap<K, V> mutableSnapshot() {
-        return new MutableTrieMap<>(new INode<>(new Gen(), root.gcasRead(this)));
+        return new MutableTrieMap<>(root.copyToGen(new Gen(), this));
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -104,7 +104,7 @@ public final class ImmutableTrieMap<K, V> extends TrieMap<K, V> {
 
     @Override
     public int size() {
-        return root.readSize(this);
+        return root.elementSize(this);
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/ImmutableTrieMap.java
@@ -109,7 +109,7 @@ public final class ImmutableTrieMap<K, V> extends TrieMap<K, V> {
 
     @Override
     public MutableTrieMap<K, V> mutableSnapshot() {
-        return new MutableTrieMap<>(root.copyToGen(new Gen(), this));
+        return new MutableTrieMap<>(root.copyToGen(this, new Gen()));
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/LNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNode.java
@@ -37,7 +37,7 @@ final class LNode<K, V> extends MainNode<K, V> {
     }
 
     @Override
-    int size(final ImmutableTrieMap<?, ?> ct) {
+    int size(final ImmutableTrieMap<K, V> ct) {
         return size;
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/LNodeEntries.java
@@ -86,19 +86,19 @@ abstract sealed class LNodeEntries<K, V> extends LNodeEntry<K, V> {
     final boolean insert(final MutableTrieMap<K, V> ct, final INode<K, V> in, final LNode<K, V> ln, final K key,
             final V val) {
         final var entry = findEntry(key);
-        return in.gcasWrite(entry == null ? toInserted(ln, key, val) : toReplaced(ln, entry, val), ct);
+        return in.gcasWrite(ct, entry == null ? toInserted(ln, key, val) : toReplaced(ln, entry, val));
     }
 
     @Nullable Result<V> insertIf(final MutableTrieMap<K, V> ct, final INode<K, V> in, final LNode<K, V> ln, final K key,
             final V val, final Object cond) {
         final var entry = findEntry(key);
         if (entry == null) {
-            return cond != null && cond != ABSENT || in.gcasWrite(toInserted(ln, key, val), ct) ? Result.empty() : null;
+            return cond != null && cond != ABSENT || in.gcasWrite(ct, toInserted(ln, key, val)) ? Result.empty() : null;
         }
         if (cond == ABSENT) {
             return entry.toResult();
         } else if (cond == null || cond == PRESENT || cond.equals(entry.value())) {
-            return in.gcasWrite(toReplaced(ln, entry, val), ct) ? entry.toResult() : null;
+            return in.gcasWrite(ct, toReplaced(ln, entry, val)) ? entry.toResult() : null;
         }
         return Result.empty();
     }
@@ -124,7 +124,7 @@ abstract sealed class LNodeEntries<K, V> extends LNodeEntry<K, V> {
         final var size = ln.size;
         final var next = size == 2 ? new TNode<>(ln, map.key(), map.value(), hc) : new LNode<>(ln, map, size - 1);
 
-        return in.gcasWrite(next, ct) ? entry.toResult() : null;
+        return in.gcasWrite(ct, next) ? entry.toResult() : null;
     }
 
     private LNode<K, V> toInserted(final LNode<K, V> ln, final K key, final V val) {

--- a/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MainNode.java
@@ -50,11 +50,10 @@ abstract sealed class MainNode<K, V> extends INode.TryGcas<K, V> permits CNode, 
     abstract int trySize();
 
     /**
-     * Return the number of entries in this node, traversing it if need be. This method should be invoked only
-     * on immutable snapshots.
+     * Return the number of entries in this node, traversing it if need be.
      *
      * @param ct TrieMap reference
      * @return The actual number of entries.
      */
-    abstract int size(ImmutableTrieMap<?, ?> ct);
+    abstract int size(ImmutableTrieMap<K, V> ct);
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -207,9 +207,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 final int pos = Integer.bitCount(bmp & mask);
 
                 if ((bmp & flag) == 0) {
-                    final var gen = current.gen;
-                    final var rn = cn.gen == gen ? cn : cn.renewed(gen, this);
-                    return current.gcasWrite(rn.toInsertedAt(cn, gen, pos, flag, key, val, hc), this);
+                    return cn.insert(this, current, pos, flag, key, val, hc);
                 }
 
                 // 1a) insert below
@@ -281,14 +279,8 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
 
                 if ((bmp & flag) == 0) {
                     // not found
-                    if (cond == null || cond == ABSENT) {
-                        final var gen = current.gen;
-                        final var rn = cn.gen == gen ? cn : cn.renewed(gen, this);
-                        if (!current.gcasWrite(rn.toInsertedAt(cn, gen, pos, flag, key, val, hc), this)) {
-                            return null;
-                        }
-                    }
-                    return Result.empty();
+                    return cond != null && cond != ABSENT || cn.insert(this, current, pos, flag, key, val, hc)
+                        ? Result.empty() : null;
                 }
 
                 // 1a) insert below

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -315,101 +315,11 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         Result<V> res;
         do {
             // Keep looping as long as we do not get a reply
-            res = recRemove(readRoot(), key, cond, hc);
+            final var r = readRoot();
+            res = r.remove(this, r.gen, hc, key, cond, 0, null);
         } while (res == null);
 
         return res;
-    }
-
-    /**
-     * Removes the key associated with the given value.
-     *
-     * @param cond
-     *            if null, will remove the key regardless of the value;
-     *            otherwise removes only if binding contains that exact key
-     *            and value
-     * @return null if not successful, an Result indicating the previous
-     *         value otherwise
-     */
-    private @Nullable Result<V> recRemove(final INode<K, V> first, final K key, final Object cond, final int hc) {
-        final var startGen = first.gen;
-        INode<K, V> parent = null;
-        var current = first;
-        int lev = 0;
-
-        while (true) {
-            final var m = current.gcasRead(this);
-
-            if (m instanceof CNode<K, V> cn) {
-                final int idx = hc >>> lev & 0x1f;
-                final int bmp = cn.bitmap;
-                final int flag = 1 << idx;
-                if ((bmp & flag) == 0) {
-                    return Result.empty();
-                }
-
-                final int pos = Integer.bitCount(bmp & flag - 1);
-                final var sub = cn.array[pos];
-                if (sub instanceof INode<K, V> in) {
-                    // renew if needed
-                    if (startGen != in.gen && !cn.renew(this, current, startGen)) {
-                        return null;
-                    }
-
-                    parent = current;
-                    current = in;
-                    lev += LEVEL_BITS;
-                } else if (sub instanceof SNode<K, V> sn) {
-                    final var res = cn.remove(this, current, flag, pos, sn, key, hc, cond, lev);
-                    // never tomb at root
-                    if (res != null && res.isPresent() && parent != null
-                        && current.gcasRead(this) instanceof TNode<K, V> tn) {
-                        cleanParent(current, tn, parent, hc, lev, startGen);
-                    }
-                    return res;
-                } else {
-                    throw invalidElement(sub);
-                }
-            } else if (m instanceof TNode) {
-                clean(current, parent, lev);
-                return null;
-            } else if (m instanceof LNode<K, V> ln) {
-                return ln.entries.remove(this, current, ln, key, cond, hc);
-            } else {
-                throw invalidElement(m);
-            }
-        }
-    }
-
-    private void cleanParent(final INode<K, V> in, final TNode<K, V> tn, final INode<K, V> parent, final int hc,
-            final int lev, final Gen startgen) {
-        while (true) {
-            if (!(parent.gcasRead(this) instanceof CNode<K, V> cn)) {
-                // parent is no longer a cnode, we're done
-                return;
-            }
-
-            final int idx = hc >>> lev - LEVEL_BITS & 0x1f;
-            final int bmp = cn.bitmap;
-            final int flag = 1 << idx;
-            if ((bmp & flag) == 0) {
-                // somebody already removed this i-node, we're done
-                return;
-            }
-
-            final int pos = Integer.bitCount(bmp & flag - 1);
-            final var sub = cn.array[pos];
-            if (sub != in) {
-                // some other range is occupying our slot, we're done
-                return;
-            }
-
-            if (parent.gcasWrite(cn.updatedAt(pos, tn.copyUntombed(), in.gen).toContracted(cn, lev - LEVEL_BITS), this)
-                || readRoot().gen != startgen) {
-                // (mumble-mumble) and we're done
-                return;
-            }
-        }
     }
 
     private Root<K, V> casRoot(final Root<K, V> prev, final Root<K, V> next) {

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -141,7 +141,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
         INode<K, V> localRoot;
         do {
             localRoot = readRoot();
-        } while (!rdcssRoot(localRoot, localRoot.gcasRead(this), localRoot.copyToGen(new Gen(), this)));
+        } while (!rdcssRoot(localRoot, localRoot.gcasRead(this), localRoot.copyToGen(this, new Gen())));
 
         return localRoot;
     }
@@ -153,7 +153,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
 
     @Override
     public MutableTrieMap<K, V> mutableSnapshot() {
-        return new MutableTrieMap<>(snapshot().copyToGen(new Gen(), this));
+        return new MutableTrieMap<>(snapshot().copyToGen(this, new Gen()));
     }
 
     @Override

--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -216,7 +216,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 final var cnAtPos = cn.array[pos];
                 if (cnAtPos instanceof INode<K, V> in) {
                     // renew if needed
-                    if (startGen != in.gen && !current.gcasWrite(cn.renewed(startGen, this), this)) {
+                    if (startGen != in.gen && !cn.renew(this, current, startGen)) {
                         return false;
                     }
 
@@ -294,7 +294,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 // 1a) insert below
                 final var cnAtPos = cn.array[pos];
                 if (cnAtPos instanceof INode<K, V> in) {
-                    if (startgen != in.gen && !current.gcasWrite(cn.renewed(startgen, this), this)) {
+                    if (startgen != in.gen && !cn.renew(this, current, startgen)) {
                         return null;
                     }
 
@@ -360,7 +360,7 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
                 final var sub = cn.array[pos];
                 if (sub instanceof INode<K, V> in) {
                     // renew if needed
-                    if (startGen != in.gen && !current.gcasWrite(cn.renewed(startGen, this), this)) {
+                    if (startGen != in.gen && !cn.renew(this, current, startGen)) {
                         return null;
                     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -36,6 +36,11 @@ record SNode<K, V>(K key, V value, int hc) implements Branch<K, V>, EntryNode<K,
     }
 
     @Override
+    public int elementSize(final ImmutableTrieMap<K, V> ct) {
+        return 1;
+    }
+
+    @Override
     public int hashCode() {
         return AbstractEntry.hashCode(key, value);
     }

--- a/triemap/src/main/java/tech/pantheon/triemap/SNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SNode.java
@@ -19,8 +19,8 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
 record SNode<K, V>(K key, V value, int hc) implements Branch<K, V>, EntryNode<K, V> {
-    TNode<K, V> copyTombed(final CNode<K, V> prev) {
-        return new TNode<>(prev, key, value, hc);
+    SNode(final TNode<K, V> tn) {
+        this(tn.key, tn.value, tn.hc);
     }
 
     @Nullable V lookup(final int otherHc, final K otherKey) {

--- a/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/SerializationProxy.java
@@ -75,7 +75,12 @@ final class SerializationProxy implements Externalizable {
         }
 
         for (int i = 0; i < size; ++i) {
-            tmp.add(in.readObject(), in.readObject());
+            final var k = requireNonNull(in.readObject());
+            final var v = requireNonNull(in.readObject());
+            final var r = tmp.readRoot();
+            if (!r.insert(tmp, r.gen, TrieMap.computeHash(k), k, v, 0, null)) {
+                throw new VerifyException("Concurrent modification during serialization");
+            }
         }
 
         map = in.readBoolean() ? tmp.immutableSnapshot() : tmp;

--- a/triemap/src/main/java/tech/pantheon/triemap/TNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TNode.java
@@ -56,7 +56,7 @@ final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
     }
 
     @Override
-    int size(final ImmutableTrieMap<?, ?> ct) {
+    int size(final ImmutableTrieMap<K, V> ct) {
         return 1;
     }
 

--- a/triemap/src/main/java/tech/pantheon/triemap/TNode.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TNode.java
@@ -20,11 +20,16 @@ final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
     final V value;
     final int hc;
 
+    // Visible for testing
     TNode(final CNode<K, V> prev, final K key, final V value, final int hc) {
         super(prev);
         this.key = key;
         this.value = value;
         this.hc = hc;
+    }
+
+    TNode(final CNode<K, V> prev, final SNode<K, V> sn) {
+        this(prev, sn.key(), sn.value(), sn.hc());
     }
 
     TNode(final LNode<K, V> prev, final K key, final V value, final int hc) {
@@ -34,9 +39,6 @@ final class TNode<K, V> extends MainNode<K, V> implements EntryNode<K, V> {
         this.hc = hc;
     }
 
-    SNode<K, V> copyUntombed() {
-        return new SNode<>(key, value, hc);
-    }
 
     @Override
     public K key() {

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -41,7 +41,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     // Virtual result for lookup methods indicating that the lookup needs to be restarted. This is a faster version
     // of throwing a checked exception to control restart.
-    private static final Object RESTART = new Object();
+    static final Object RESTART = new Object();
 
     private transient AbstractEntrySet<K, V, ?> entrySet;
     // Note: AbstractMap.keySet is something we do not have access to. At some point we should just not subclass
@@ -112,10 +112,18 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public final V get(final Object key) {
-        @SuppressWarnings("unchecked")
         final var k = (K) requireNonNull(key);
-        return lookuphc(k, computeHash(k));
+        final var hc = computeHash(k);
+
+        // Keep looping as long as RESTART is being returned
+        Object res;
+        do {
+            res = readRoot().lookup(this, hc, k);
+        } while (res == RESTART);
+
+        return (V) res;
     }
 
     @Override
@@ -208,83 +216,6 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
     }
 
     /* private implementation methods */
-
-    @SuppressWarnings("unchecked")
-    private V lookuphc(final K key, final int hc) {
-        Object res;
-        do {
-            // Keep looping as long as RESTART is being indicated
-            res = recLookup(readRoot(), key, hc);
-        } while (res == RESTART);
-
-        return (V) res;
-    }
-
-    /**
-     * Looks up the value associated with the key.
-     *
-     * @param first root {@link INode}
-     * @param key the key
-     * @param the hash code
-     * @return null if no value has been found, RESTART if the operation was not successful, or any other value
-     *              otherwise
-     */
-    private Object recLookup(final INode<K, V> first, final K key, final int hc) {
-        final var startGen = first.gen;
-        INode<K, V> parent = null;
-        var current = first;
-        int lev = 0;
-
-        while (true) {
-            final var m = current.gcasRead(this);
-
-            if (m instanceof CNode<K, V> cn) {
-                // 1) a multinode
-                final int idx = hc >>> lev & 0x1f;
-                final int flag = 1 << idx;
-
-                final int bmp = cn.bitmap;
-                if ((bmp & flag) == 0) {
-                    // 1a) bitmap shows no binding
-                    return null;
-                }
-
-                // 1b) bitmap contains a value - descend
-                final int pos = bmp == 0xffffffff ? idx : Integer.bitCount(bmp & flag - 1);
-                final var sub = cn.array[pos];
-                if (sub instanceof INode<K, V> in) {
-                    // try to renew if needed
-                    if (!isReadOnly() && startGen != in.gen && !cn.renew(this, current, startGen)) {
-                        return RESTART;
-                    }
-
-                    // enter next level
-                    parent = current;
-                    current = in;
-                    lev += LEVEL_BITS;
-                } else if (sub instanceof SNode<K, V> sn) {
-                    // 2) singleton node
-                    return sn.lookup(hc, key);
-                } else {
-                    throw invalidElement(sub);
-                }
-            } else if (m instanceof TNode<K, V> tn) {
-                // 3) non-live node
-                if (isReadOnly()) {
-                    // read-only side does not clean up
-                    return tn.hc == hc && key.equals(tn.key) ? tn.value : null;
-                }
-                // read-write: perform some clean up and restart
-                clean(current, parent, lev - LEVEL_BITS);
-                return RESTART;
-            } else if (m instanceof LNode<K, V> ln) {
-                // 5) an l-node
-                return ln.entries.lookup(key);
-            } else {
-                throw invalidElement(m);
-            }
-        }
-    }
 
     final void clean(final INode<K, V> current, final INode<K, V> parent, final int lev) {
         if (parent.gcasRead(this) instanceof CNode<K, V> cn) {

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -16,7 +16,6 @@
 package tech.pantheon.triemap;
 
 import static java.util.Objects.requireNonNull;
-import static tech.pantheon.triemap.Constants.LEVEL_BITS;
 
 import java.io.Serializable;
 import java.util.AbstractMap;
@@ -214,21 +213,5 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
     // FIXME: abort = false by default
     final INode<K, V> readRoot(final boolean abort) {
         return rdcssReadRoot(abort);
-    }
-
-    /* private implementation methods */
-
-    final void clean(final INode<K, V> current, final INode<K, V> parent, final int lev) {
-        if (parent.gcasRead(this) instanceof CNode<K, V> cn) {
-            parent.gcasWrite(cn.toCompressed(this, lev  - LEVEL_BITS, current.gen), this);
-        }
-    }
-
-    static final VerifyException invalidElement(final Branch<?, ?> elem) {
-        throw new VerifyException("A CNode can contain only INodes and SNodes, not " + elem);
-    }
-
-    static final VerifyException invalidElement(final MainNode<?, ?> elem) {
-        throw new VerifyException("An INode can host only a CNode, a TNode or an LNode, not " + elem);
     }
 }

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -120,7 +120,8 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
         // Keep looping as long as RESTART is being returned
         Object res;
         do {
-            res = readRoot().lookup(this, hc, k);
+            final var root = readRoot();
+            res = root.lookup(this, root.gen, hc, k, 0, null);
         } while (res == RESTART);
 
         return (V) res;

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -254,7 +254,7 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
                 final var sub = cn.array[pos];
                 if (sub instanceof INode<K, V> in) {
                     // try to renew if needed
-                    if (!isReadOnly() && startGen != in.gen && !current.gcasWrite(cn.renewed(startGen, this), this)) {
+                    if (!isReadOnly() && startGen != in.gen && !cn.renew(this, current, startGen)) {
                         return RESTART;
                     }
 

--- a/triemap/src/test/java/tech/pantheon/triemap/CNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/CNodeTest.java
@@ -28,6 +28,6 @@ class CNodeTest {
 
     @Test
     void testInvalidElement() {
-        assertThrows(VerifyException.class, () -> TrieMap.invalidElement((CNode<?, ?>) null));
+        assertThrows(VerifyException.class, () -> CNode.invalidElement(null));
     }
 }

--- a/triemap/src/test/java/tech/pantheon/triemap/INodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/INodeTest.java
@@ -24,7 +24,7 @@ import tech.pantheon.triemap.INode.FailedGcas;
 class INodeTest {
     @Test
     void testInvalidElement() {
-        assertThrows(VerifyException.class, () -> TrieMap.invalidElement((INode<?, ?>) null));
+        assertThrows(VerifyException.class, () -> INode.invalidElement(null));
     }
 
     @Test

--- a/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/SNodeTest.java
@@ -30,7 +30,7 @@ class SNodeTest {
 
     @Test
     void testCopyTombed() {
-        final var tnode = snode.copyTombed(new CNode<>(new Gen()));
+        final var tnode = new TNode<>(new CNode<>(new Gen()), snode);
         assertEquals(snode.hashCode(), tnode.hashCode());
         assertSame(snode.key(), tnode.key());
         assertSame(snode.value(), tnode.value());

--- a/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TNodeTest.java
@@ -30,7 +30,7 @@ class TNodeTest {
 
     @Test
     void testCopyUntombed() {
-        final var snode = tnode.copyUntombed();
+        final var snode = new SNode<>(tnode);
         assertEquals(tnode.hashCode(), snode.hashCode());
         assertSame(tnode.key(), snode.key());
         assertSame(tnode.value(), snode.value());


### PR DESCRIPTION
This refactors out TrieMap.recLookup() and all MutableTrieMap mutators
so they descend the tree hierarchy via CNode/INode recursion, ending our
refactoring efforts.

The end delta since triemap-1.3.2 ends up being the break up of INode.rec*
methods driven by us choosing a different strategy enabled by
INode.gcasWrite() being exposed to the outside world -- thus any of
CNode/INode/LNode can use it as needed.

- **Add CNode.renew()**
- **Add CNode.insert()**
- **Move TrieMap.recLookup()**
- **Refactor INode.lookup()**
- **Split out {C,I}Node.remove()**
- **Split out {C,I}Node.insert() and .insertIf()**
- **Clean up MutableTrieMap method layout**
