### PR TITLE
Add TrieMap.computeIfAbsent()

### DIFF
--- a/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/MutableTrieMap.java
@@ -23,6 +23,7 @@ import static tech.pantheon.triemap.Result.RESTART;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.util.function.Function;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
@@ -133,6 +134,24 @@ public final class MutableTrieMap<K, V> extends TrieMap<K, V> {
             // Keep looping as long as we do not get a reply
             final var r = readRoot();
             res = r.remove(this, r.gen, hc, key, cond, 0, null);
+        } while (res == RESTART);
+
+        return (V) res;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public V computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction) {
+        final var k = requireNonNull(key);
+        final int hc = computeHash(key);
+        final var fn = requireNonNull(mappingFunction);
+
+        // Keep looping as long as RESTART is being returned
+        Object res;
+        do {
+            // Keep looping as long as we do not get a reply
+            final var r = readRoot();
+            res = r.computeIfAbsent(this, r.gen, hc, k, fn, 0, null);
         } while (res == RESTART);
 
         return (V) res;

--- a/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
+++ b/triemap/src/main/java/tech/pantheon/triemap/TrieMap.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.AbstractMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /**
  * This is a port of Scala's TrieMap class from the Scala Collections library. This implementation does not support
@@ -143,6 +144,9 @@ public abstract sealed class TrieMap<K, V> extends AbstractMap<K, V> implements 
 
     @Override
     public abstract V replace(K key, V value);
+
+    @Override
+    public abstract V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction);
 
     @Override
     public abstract int size();

--- a/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfAbsent.java
+++ b/triemap/src/test/java/tech/pantheon/triemap/TestConcurrentMapComputeIfAbsent.java
@@ -16,6 +16,7 @@
 package tech.pantheon.triemap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -38,7 +39,7 @@ class TestConcurrentMapComputeIfAbsent {
         for (int i = 0; i < COUNT; i++) {
             map.put(i, Integer.toString(i));
             assertEquals(Integer.toString(i), map.computeIfAbsent(i,
-                    (ignored) -> fail("Should not have called function")));
+                    ignored -> fail("Should not have called function")));
         }
     }
 
@@ -62,5 +63,12 @@ class TestConcurrentMapComputeIfAbsent {
         assertSame(v3, map.computeIfAbsent(k3, k -> v3));
         // Check with equivalent key
         assertSame(v3, map.computeIfAbsent(k3dup, k -> v3));
+    }
+
+    @Test
+    void testComputeNull() {
+        final var map = TrieMap.create();
+        assertNull(map.computeIfAbsent("key", k -> null));
+        assertEquals("{}", map.toString());
     }
 }


### PR DESCRIPTION
This is another logical operation -- combining lookup with insert. This
patch adds explicit support for it, so it happens in a single pass (most
of the time).

Note that concurrent activity may lead to the value being computed
multiple times.

Nevertheless fixes #147.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
