### PR TITLE
Bump odlparent to 14.0.5

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>13.1.5</version>
+        <version>14.0.5</version>
         <relativePath />
     </parent>
 

--- a/dependency-check/pom.xml
+++ b/dependency-check/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent</artifactId>
-        <version>13.1.5</version>
+        <version>14.0.5</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>odlparent-lite</artifactId>
-        <version>13.1.5</version>
+        <version>14.0.5</version>
         <relativePath />
     </parent>
 

--- a/pt-triemap/pom.xml
+++ b/pt-triemap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>single-feature-parent</artifactId>
-        <version>13.1.5</version>
+        <version>14.0.5</version>
         <relativePath />
     </parent>
 

--- a/triemap/pom.xml
+++ b/triemap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.opendaylight.odlparent</groupId>
         <artifactId>bnd-parent</artifactId>
-        <version>13.1.5</version>
+        <version>14.0.5</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Switch to using Java 21 by adopting odlparent-14.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
