### PR TITLE
Use Java 21 for workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,10 +22,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
 
     - name: Cache Maven packages


### PR DESCRIPTION
We are about to require Java 21, make sure we build with it.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
